### PR TITLE
Reusable filter components

### DIFF
--- a/common/api/realestateApi/realestate.api.ts
+++ b/common/api/realestateApi/realestate.api.ts
@@ -19,7 +19,7 @@ export const realestateApi = createApi({
       {
         limit?: number
         domainId?: string
-        streetId?: string
+        streetId?: string[]
         companyId?: string
         domainIds?: string[]
         companyIds?: string[]

--- a/common/api/realestateApi/realestate.api.types.ts
+++ b/common/api/realestateApi/realestate.api.types.ts
@@ -33,6 +33,7 @@ export interface IGetRealestateResponse {
   data: IExtendedRealestate[]
   domainsFilter: IFilter[]
   realEstatesFilter: IFilter[]
+  streetsFilter: IFilter[]
 }
 
 export interface IDeleteRealestateResponse {

--- a/common/components/DashboardPage/blocks/realEstates.tsx
+++ b/common/components/DashboardPage/blocks/realEstates.tsx
@@ -36,10 +36,10 @@ const RealEstateBlock: React.FC<Props> = ({
     isError,
   } = useGetAllRealEstateQuery({
     domainId,
-    streetId,
     limit: isOnPage ? 0 : 5,
     companyIds: filters?.company || undefined,
     domainIds: filters?.domain || undefined,
+    streetId: filters?.street || undefined
   })
   
   return (

--- a/common/components/Tables/Companies/Header.tsx
+++ b/common/components/Tables/Companies/Header.tsx
@@ -15,7 +15,7 @@ import FilterTags from '@common/components/UI/Reusable/FilterTags'
 import s from './style.module.scss'
 import DomainFilterSelector from '@common/components/UI/Reusable/FilterSelectors/DomainFilterSelecter'
 import CompanyFilterSelector from '@common/components/UI/Reusable/FilterSelectors/CompanyFilterSelector'
-// import StreetFilterSelector from '@common/components/UI/Reusable/FilterSelectors/StreetFilterSelector'
+import StreetFilterSelector from '@common/components/UI/Reusable/FilterSelectors/StreetFilterSelector'
 
 export interface Props {
   showAddButton?: boolean
@@ -61,13 +61,12 @@ const CompaniesHeader: React.FC<Props> = ({
               setFilters={setFilters}
               domainsFilter={realEstates?.domainsFilter}
             />
-            {/* Possible streets-based filters support */}
-            {/* <StreetFilterSelector
+            <StreetFilterSelector
               style={{ marginLeft: '1rem' }}
               filters={filters}
               setFilters={setFilters}
               streetsFilter={realEstates?.streetsFilter}
-            /> */}
+            />
             <CompanyFilterSelector
               style={{ marginLeft: '1rem' }}
               filters={filters}

--- a/common/components/Tables/Companies/Header.tsx
+++ b/common/components/Tables/Companies/Header.tsx
@@ -13,6 +13,9 @@ import {
 } from '@common/api/realestateApi/realestate.api.types'
 import FilterTags from '@common/components/UI/Reusable/FilterTags'
 import s from './style.module.scss'
+import DomainFilterSelector from '@common/components/UI/Reusable/FilterSelectors/DomainFilterSelecter'
+import CompanyFilterSelector from '@common/components/UI/Reusable/FilterSelectors/CompanyFilterSelector'
+// import StreetFilterSelector from '@common/components/UI/Reusable/FilterSelectors/StreetFilterSelector'
 
 export interface Props {
   showAddButton?: boolean
@@ -51,8 +54,26 @@ const CompaniesHeader: React.FC<Props> = ({
           <SelectOutlined />
         </Button>
 
-        {router.pathname === AppRoutes.REAL_ESTATE && isAdmin &&  (
+        {router.pathname === AppRoutes.REAL_ESTATE && isAdmin && (
           <>
+            <DomainFilterSelector
+              filters={filters}
+              setFilters={setFilters}
+              domainsFilter={realEstates?.domainsFilter}
+            />
+            {/* Possible streets-based filters support */}
+            {/* <StreetFilterSelector
+              style={{ marginLeft: '1rem' }}
+              filters={filters}
+              setFilters={setFilters}
+              streetsFilter={realEstates?.streetsFilter}
+            /> */}
+            <CompanyFilterSelector
+              style={{ marginLeft: '1rem' }}
+              filters={filters}
+              setFilters={setFilters}
+              companiesFilter={realEstates?.realEstatesFilter}
+            />
             <FilterTags
               filters={filters}
               setFilters={setFilters}

--- a/common/components/Tables/Companies/Table.tsx
+++ b/common/components/Tables/Companies/Table.tsx
@@ -92,6 +92,7 @@ const CompaniesTable: React.FC<Props> = ({
         setFilters({
           domain: filters?.domain,
           company: filters?.companyName,
+          address: filters?.address,
         })
       }}
     />

--- a/common/components/UI/DomainsComponents/DomainModal/index.tsx
+++ b/common/components/UI/DomainsComponents/DomainModal/index.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 const DomainModal: FC<Props> = ({ currentDomain, closeModal }) => {
   const [form] = Form.useForm()
-  let errorType = ('')
+   let errorType = ('')
   const [addDomainEstate] = useAddDomainMutation()
   const [editDomain] = useEditDomainMutation()
 

--- a/common/components/UI/DomainsComponents/DomainModal/index.tsx
+++ b/common/components/UI/DomainsComponents/DomainModal/index.tsx
@@ -18,6 +18,7 @@ interface Props {
 
 const DomainModal: FC<Props> = ({ currentDomain, closeModal }) => {
   const [form] = Form.useForm()
+  let errorType = ('')
   const [addDomainEstate] = useAddDomainMutation()
   const [editDomain] = useEditDomainMutation()
 
@@ -33,6 +34,12 @@ const DomainModal: FC<Props> = ({ currentDomain, closeModal }) => {
       description: formData.description,
     }
 
+    if(!domainData.streets.some((i: any) => i.value))
+      errorType = 'adress'
+    // else if
+    else 
+      errorType = ''
+
     const response = currentDomain
       ? await editDomain({
           _id: currentDomain?._id,
@@ -43,11 +50,16 @@ const DomainModal: FC<Props> = ({ currentDomain, closeModal }) => {
     if ('data' in response) {
       form.resetFields()
       closeModal()
+      
       const action = currentDomain ? 'Збережено' : 'Додано'
       message.success(action)
-    } else {
+    } else { 
       const action = currentDomain ? 'збереженні' : 'додаванні'
-      message.error(`Помилка при ${action} надавача послуг`)
+      if(errorType === 'adress') 
+        message.error(`Адреса не знайдена`)
+      // else if
+      else 
+        message.error(`Помилка при ${action} надавача послуг`)
     }
   }
 

--- a/common/components/UI/DomainsComponents/DomainModal/index.tsx
+++ b/common/components/UI/DomainsComponents/DomainModal/index.tsx
@@ -18,7 +18,6 @@ interface Props {
 
 const DomainModal: FC<Props> = ({ currentDomain, closeModal }) => {
   const [form] = Form.useForm()
-   let errorType = ('')
   const [addDomainEstate] = useAddDomainMutation()
   const [editDomain] = useEditDomainMutation()
 
@@ -34,12 +33,6 @@ const DomainModal: FC<Props> = ({ currentDomain, closeModal }) => {
       description: formData.description,
     }
 
-    if(!domainData.streets.some((i: any) => i.value))
-      errorType = 'adress'
-    // else if
-    else 
-      errorType = ''
-
     const response = currentDomain
       ? await editDomain({
           _id: currentDomain?._id,
@@ -50,16 +43,11 @@ const DomainModal: FC<Props> = ({ currentDomain, closeModal }) => {
     if ('data' in response) {
       form.resetFields()
       closeModal()
-      
       const action = currentDomain ? 'Збережено' : 'Додано'
       message.success(action)
-    } else { 
+    } else {
       const action = currentDomain ? 'збереженні' : 'додаванні'
-      if(errorType === 'adress') 
-        message.error(`Адреса не знайдена`)
-      // else if
-      else 
-        message.error(`Помилка при ${action} надавача послуг`)
+      message.error(`Помилка при ${action} надавача послуг`)
     }
   }
 

--- a/common/components/UI/RealEstateComponents/RealEstateModal/index.tsx
+++ b/common/components/UI/RealEstateComponents/RealEstateModal/index.tsx
@@ -38,7 +38,7 @@ const RealEstateModal: FC<Props> = ({ closeModal, currentRealEstate }) => {
       rentPart: formData.rentPart,
       inflicion: formData.inflicion,
       waterPart: formData.waterPart,
-      discount: formData.discount * -1,
+      discount: formData.discount > 0 ? formData.discount * -1 : formData.discount,
       cleaning: formData.cleaning,
     }
 

--- a/common/components/UI/Reusable/FilterSelectors/CompanyFilterSelector.tsx
+++ b/common/components/UI/Reusable/FilterSelectors/CompanyFilterSelector.tsx
@@ -1,0 +1,58 @@
+import { Selector } from '@common/components/UI/Reusable/Selector'
+
+export interface ICompanyFilterSelectorOption {
+  text?: string
+  label?: string
+  value: string
+}
+
+export interface ICompanyFilterSelectorProps {
+  filters: any // TODO: proper typing
+  companiesFilter: ICompanyFilterSelectorOption[]
+  setFilters: (...args: any) => any
+  style?: React.CSSProperties
+  className?: string
+}
+
+const CompanyFilterSelector: React.FC<ICompanyFilterSelectorProps> = (
+  props
+) => {
+  return (
+    <Selector
+      style={props.style}
+      className={props.className}
+      placeholder="Оберіть компанію..."
+      selected={
+        props.filters?.company?.length === 1
+          ? props.filters.company[0]
+          : undefined
+      }
+      onSelect={(value) =>
+        props.setFilters({ ...props.filters, company: [value] })
+      }
+      // Possible multiselect support
+      // onSelect={(value) =>
+      //   props.setFilters({
+      //     ...props.filters,
+      //     company: Array.isArray(props.filters?.company)
+      //       ? [...props.filters.company, value]
+      //       : [value],
+      //   })
+      // }
+      // onDeselect={(value) =>
+      //   props.setFilters({
+      //     ...props.filters,
+      //     company: props.filters?.company?.filter((company) => company !== value),
+      //   })
+      // }
+      onClear={() => props.setFilters({ ...props.filters, company: undefined })}
+      options={props.companiesFilter?.map((option) => ({
+        // .label instead of .text (antd renders .value if .label is not presented)
+        label: option.label || option.text || option.value,
+        value: option.value,
+      }))}
+    />
+  )
+}
+
+export default CompanyFilterSelector

--- a/common/components/UI/Reusable/FilterSelectors/DomainFilterSelecter.tsx
+++ b/common/components/UI/Reusable/FilterSelectors/DomainFilterSelecter.tsx
@@ -1,0 +1,56 @@
+import { Selector } from '@common/components/UI/Reusable/Selector'
+
+export interface IDomainFilterSelectorOption {
+  text?: string
+  label?: string
+  value: string
+}
+
+export interface IDomainFilterSelectorProps {
+  filters: any // TODO: proper typing
+  domainsFilter: IDomainFilterSelectorOption[]
+  setFilters: (...args: any) => any
+  style?: React.CSSProperties
+  className?: string
+}
+
+const DomainFilterSelector: React.FC<IDomainFilterSelectorProps> = (props) => {
+  return (
+    <Selector
+      style={props.style}
+      className={props.className}
+      placeholder="Оберіть надавача послуг..."
+      selected={
+        props.filters?.domain?.length === 1
+          ? props.filters.domain[0]
+          : undefined
+      }
+      onSelect={(value) =>
+        props.setFilters({ ...props.filters, domain: [value] })
+      }
+      // Possible multiselect support
+      // onSelect={(value) =>
+      //   props.setFilters({
+      //     ...props.filters,
+      //     domain: Array.isArray(props.filters?.domain)
+      //       ? [...props.filters.domain, value]
+      //       : [value],
+      //   })
+      // }
+      // onDeselect={(value) =>
+      //   props.setFilters({
+      //     ...props.filters,
+      //     domain: props.filters?.domain?.filter((domain) => domain !== value),
+      //   })
+      // }
+      onClear={() => props.setFilters({ ...props.filters, domain: undefined })}
+      options={props.domainsFilter?.map((option) => ({
+        // .label instead of .text (antd renders .value if .label is not presented)
+        label: option.label || option.text || option.value,
+        value: option.value,
+      }))}
+    />
+  )
+}
+
+export default DomainFilterSelector

--- a/common/components/UI/Reusable/FilterSelectors/StreetFilterSelector.tsx
+++ b/common/components/UI/Reusable/FilterSelectors/StreetFilterSelector.tsx
@@ -1,0 +1,56 @@
+import { Selector } from '@common/components/UI/Reusable/Selector'
+
+export interface IStreetFilterSelectorOption {
+  text?: string
+  label?: string
+  value: string
+}
+
+export interface IStreetFilterSelectorProps {
+  filters: any // TODO: proper typing
+  streetsFilter: IStreetFilterSelectorOption[]
+  setFilters: (...args: any) => any
+  style?: React.CSSProperties
+  className?: string
+}
+
+const StreetFilterSelector: React.FC<IStreetFilterSelectorProps> = (props) => {
+  return (
+    <Selector
+      style={props.style}
+      className={props.className}
+      placeholder="Оберіть адресу..."
+      selected={
+        props.filters?.street?.length === 1
+          ? props.filters.street[0]
+          : undefined
+      }
+      onSelect={(value) =>
+        props.setFilters({ ...props.filters, street: [value] })
+      }
+      // Possible multiselect support
+      // onSelect={(value) =>
+      //   props.setFilters({
+      //     ...props.filters,
+      //     street: Array.isArray(props.filters?.street)
+      //       ? [...props.filters.street, value]
+      //       : [value],
+      //   })
+      // }
+      // onDeselect={(value) =>
+      //   props.setFilters({
+      //     ...props.filters,
+      //     street: props.filters?.street?.filter((street) => street !== value),
+      //   })
+      // }
+      onClear={() => props.setFilters({ ...props.filters, street: undefined })}
+      options={props.streetsFilter?.map((option) => ({
+        // .label instead of .text (antd renders .value if .label is not presented)
+        label: option.label || option.text || option.value,
+        value: option.value,
+      }))}
+    />
+  )
+}
+
+export default StreetFilterSelector

--- a/common/components/UI/Reusable/FilterTags/index.tsx
+++ b/common/components/UI/Reusable/FilterTags/index.tsx
@@ -6,8 +6,8 @@ const FilterTags = ({ filters, setFilters, collection }) => {
     <>
       <div className={s.filtersTagsBlock}>
         <div className={s.filters}>
-        Надавачі послуг:
-          {filters?.domain?.length ? (
+          Надавачі послуг:
+          {Array.isArray(filters?.domain) && filters.domain.length ? (
             <span className={s.filtersTags}>
               {filters.domain.map((domain) => (
                 <Tag
@@ -29,8 +29,8 @@ const FilterTags = ({ filters, setFilters, collection }) => {
                 </Tag>
               ))}
             </span>
-          ) : (collection?.currentDomainsCount ||
-              collection?.domainsFilter?.length) === 1 ? (
+          ) : collection?.currentDomainsCount ||
+            collection?.domainsFilter?.length === 1 ? (
             <SingleTag name={collection?.data?.[0]?.domain?.name} />
           ) : (
             ' Всі'
@@ -38,7 +38,7 @@ const FilterTags = ({ filters, setFilters, collection }) => {
         </div>
         <div className={s.filters}>
           Компанії:
-          {filters?.company?.length ? (
+          {Array.isArray(filters?.company) && filters.company.length ? (
             <div className={s.filtersTags}>
               {filters.company.map((company) => (
                 <Tag

--- a/common/components/UI/Reusable/Selector/index.tsx
+++ b/common/components/UI/Reusable/Selector/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Select } from 'antd'
+import classNames from 'classnames'
+import s from './style.module.scss'
+
+export interface ISelectorOption {
+  label: string
+  value: any
+}
+
+export interface ISelectorProps {
+  options?: ISelectorOption[]
+  selected?: any
+  onChange?: (value: any, option: any) => any
+  onSelect?: (value: any, option: any) => any
+  onDeselect?: (value: any, option: any) => any
+  onClear?: () => void
+  placeholder?: string
+  style?: React.CSSProperties
+  className?: string
+}
+
+const filterOption = (
+  input: string,
+  option?: { label: string; value: string }
+) => (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+
+export const Selector: React.FC<ISelectorProps> = (props) => {
+  return (
+    <Select
+      style={props.style}
+      className={classNames(s.Selector, props.className)}
+      placeholder={props.placeholder || 'Виберіть...'}
+      value={props.selected}
+      options={props.options}
+      onChange={props.onChange}
+      onSelect={props.onSelect}
+      onDeselect={props.onDeselect}
+      onClear={props.onClear}
+      filterOption={filterOption}
+      showSearch
+      allowClear
+    />
+  )
+}

--- a/common/components/UI/Reusable/Selector/style.module.scss
+++ b/common/components/UI/Reusable/Selector/style.module.scss
@@ -1,0 +1,10 @@
+.Selector {
+  min-width: 200px;
+  width: 100%;
+  height: 32px;
+
+  :global(.ant-select-selector) {
+    width: 100% !important;
+    height: 100% !important;
+  }
+}

--- a/pages/api/real-estate/index.ts
+++ b/pages/api/real-estate/index.ts
@@ -34,7 +34,6 @@ export default async function handler(
         } = req.query
 
         if (domainId) options.domain = domainId
-        if (streetId) options.street = streetId
         if (companyId) options._id = companyId
 
         if (domainIds) {
@@ -43,6 +42,9 @@ export default async function handler(
 
         if (companyIds) {
           options._id = filterOptions(options?._id, companyIds)
+        }
+        if (streetId) {
+          options.street = filterOptions(options?.street, streetId)
         }
 
         if (isDomainAdmin) {

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,6 +1,6 @@
-import User from '@common/modules/models/User'
+import User, { IUser } from '@common/modules/models/User'
 import { FormInstance } from 'antd'
-import { ObjectId } from 'mongoose'
+import mongoose, { ObjectId } from 'mongoose'
 import { Roles, ServiceType } from './constants'
 import { PaymentOptions } from './types'
 import moment from 'moment'
@@ -280,6 +280,24 @@ export function filterOptions(options = {}, filterIds: any) {
   }
   res.$in = idsFromQueryFilter
   return res
+}
+
+export async function getDistinctStreets({
+  user,
+  model,
+}: {
+  user: IUser
+  model: mongoose.Model<any>
+}): Promise<{ _id: mongoose.ObjectId; streetData: any }[] | undefined> {
+  // TODO: group of user roles helpers maybe? Such as isGlobalAdmin(user: IUser): boolean
+  const isGlobalAdmin = user?.roles?.includes(Roles.GLOBAL_ADMIN)
+  const domainsPipeline = getDomainsPipeline(isGlobalAdmin, user.email)
+  const distinctDomains = await model.aggregate(domainsPipeline)
+  const streetsPipeline = getStreetsPipeline(
+    isGlobalAdmin,
+    distinctDomains.map((domain) => domain._id)
+  )
+  return await model.aggregate(streetsPipeline)
 }
 
 export async function getDistinctCompanyAndDomain({


### PR DESCRIPTION
- add basic reusable selector component
- add filter-targeted selectors (`DomainFilterSelector`, `CompanyFilterSelector`, `StreetFilterSelector`)
- add `getDistinctStreets()` helper
- extend company api to fetch `streetsData` for filters
- fix some errors appeared in process