### PR TITLE
Jest: mail on payment

### DIFF
--- a/common/api/emailApi/email.api.types.ts
+++ b/common/api/emailApi/email.api.types.ts
@@ -1,4 +1,6 @@
 export interface IEmailModel {
+  domainId: string
+  companyId: string
   from?: string
   to?: string | string[]
   subject?: string

--- a/pages/api/send-email/index.ts
+++ b/pages/api/send-email/index.ts
@@ -1,8 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import nodemailer from 'nodemailer'
 
+import { IRealestate } from '@common/api/realestateApi/realestate.api.types'
+import Domain, { IDomain } from '@common/modules/models/Domain'
+import RealEstate from '@common/modules/models/RealEstate'
+import { getCurrentUser } from '@utils/getCurrentUser'
+import { IEmailModel } from '@common/api/emailApi/email.api.types'
+
 const transporter = nodemailer.createTransport(
   {
+    // service: 'gmail',
     host: process.env.EMAIL_SERVER_HOST,
     port: Number(process.env.EMAIL_SERVER_PORT) || 3000,
     secure: true,
@@ -20,13 +27,54 @@ export default async function handler(
 ) {
   switch (req.method) {
     case 'GET': {
-      return res.status(200).json({ success: true, data: '' })
+      try {
+        return res.status(200).json({ success: true, data: '' })
+      } catch (error) {
+        return res.status(400).json({ success: false, error: error })
+      }
     }
     case 'POST': {
       try {
-        const info = await transporter.sendMail(req.body)
+        const { companyId, domainId, ...body }: IEmailModel = req.body
 
-        return res.status(201).json({ success: false, data: info })
+        if (!domainId) {
+          throw new Error('provider is not specified')
+        }
+        if (!companyId) {
+          throw new Error('receiver is not specified')
+        }
+
+        const { isDomainAdmin, isGlobalAdmin, user } = await getCurrentUser(
+          req,
+          res
+        )
+
+        if (!isGlobalAdmin && !isDomainAdmin) {
+          throw new Error('restricted access')
+        }
+
+        const domain: IDomain = await Domain.findById(domainId)
+        if (!isGlobalAdmin && !domain) {
+          throw new Error('unknown provider')
+        }
+        if (!isGlobalAdmin && !domain.adminEmails.includes(user.email)) {
+          throw new Error('restricted access')
+        }
+
+        const company: IRealestate = await RealEstate.findById(companyId)
+        if (!isGlobalAdmin && !company) {
+          throw new Error('unknown receiver')
+        }
+        if (
+          !isGlobalAdmin &&
+          company.domain._id.toString() !== domain._id.toString()
+        ) {
+          throw new Error('restricted access')
+        }
+
+        const response = await transporter.sendMail(body)
+
+        return res.status(201).json({ success: true, data: response })
       } catch (error) {
         return res.status(400).json({ success: false, error: error })
       }

--- a/pages/api/send-email/send-email.test.ts
+++ b/pages/api/send-email/send-email.test.ts
@@ -1,0 +1,283 @@
+import { expect } from '@jest/globals'
+import handler from '.'
+
+import { dateToDefaultFormat } from '@common/assets/features/formatDate'
+import { Roles } from '@utils/constants'
+import { mockLoginAs } from '@utils/mockLoginAs'
+// TODO: separated test of pdf creation
+// import { generateHtmlFromThemplate } from '@utils/pdf/pdfThemplate'
+import { setupTestEnvironment } from '@utils/setupTestEnvironment'
+import { domains, payments, realEstates, users } from '@utils/testData'
+
+jest.mock('next-auth', () => ({ getServerSession: jest.fn() }))
+jest.mock('@pages/api/auth/[...nextauth]', () => ({ authOptions: {} }))
+jest.mock('@pages/api/api.config', () => jest.fn())
+
+setupTestEnvironment()
+
+describe('SendMail API - GET', () => {
+  it('should get empty response', async () => {
+    const mockReq = {
+      method: 'GET',
+      query: {},
+    } as any
+    const mockRes = {
+      status: jest.fn(() => mockRes),
+      json: jest.fn(),
+    } as any
+
+    await handler(mockReq, mockRes)
+
+    const response = {
+      status: mockRes.status,
+      data: mockRes.json.mock.lastCall[0].data,
+    }
+
+    expect(response.status).toHaveBeenCalledWith(200)
+
+    const received = response.data
+    const expected = ''
+
+    expect(received).toEqual(expected)
+  })
+})
+
+describe('SendMail API - POST', () => {
+  it('should send email as DomainAdmin', async () => {
+    const payment = payments.find(
+      ({ _id }) => _id === '64d68421d9ba2fc8fea79d63'
+    )
+    const domain = domains.find(({ _id }) => _id === payment.domain)
+    const company = realEstates.find(({ _id }) => _id === payment.company)
+    const defaultDateFormat = dateToDefaultFormat(
+      payment.invoiceCreationDate.toString()
+    )
+
+    await mockLoginAs({
+      email: domain.adminEmails?.[0],
+      roles: [Roles.DOMAIN_ADMIN],
+    })
+
+    const mockReq = {
+      method: 'POST',
+      body: {
+        domainId: domain?._id,
+        companyId: company?._id,
+        to: ['ligos36529@cmheia.com'],
+        subject: `Оплата від ${defaultDateFormat}`,
+        text: `Ви отримали новий рахунок від "${payment.domain}" за ${defaultDateFormat}`,
+        // html: await generateHtmlFromThemplate(payment),
+      },
+    } as any
+    const mockRes = {
+      status: jest.fn(() => mockRes),
+      json: jest.fn(),
+    } as any
+
+    await handler(mockReq, mockRes)
+
+    const response = {
+      status: mockRes.status,
+      data: mockRes.json.mock.lastCall[0].data,
+    }
+
+    expect(response.status).toHaveBeenCalledWith(201)
+  })
+
+  it('should send email as GlobalAdmin', async () => {
+    const payment = payments.find(
+      ({ _id }) => _id === '64d68421d9ba2fc8fea79d63'
+    )
+    const domain = domains.find(({ _id }) => _id === payment.domain)
+    const company = realEstates.find(({ _id }) => _id === payment.company)
+    const defaultDateFormat = dateToDefaultFormat(
+      payment.invoiceCreationDate.toString()
+    )
+
+    await mockLoginAs({
+      email: domain.adminEmails?.[0],
+      roles: [Roles.GLOBAL_ADMIN],
+    })
+
+    const mockReq = {
+      method: 'POST',
+      body: {
+        domainId: domain?._id,
+        companyId: company?._id,
+        to: ['ligos36529@cmheia.com'],
+        subject: `Оплата від ${defaultDateFormat}`,
+        text: `Ви отримали новий рахунок від "${payment.domain}" за ${defaultDateFormat}`,
+        // html: await generateHtmlFromThemplate(payment),
+      },
+    } as any
+    const mockRes = {
+      status: jest.fn(() => mockRes),
+      json: jest.fn(),
+    } as any
+
+    await handler(mockReq, mockRes)
+
+    const response = {
+      status: mockRes.status,
+      data: mockRes.json.mock.lastCall[0].data,
+    }
+
+    expect(response.status).toHaveBeenCalledWith(201)
+  })
+
+  it('should send email as GlobalAdmin of another domain', async () => {
+    const payment = payments.find(
+      ({ _id }) => _id === '64d68421d9ba2fc8fea79d63'
+    )
+    const domain = domains.find(({ _id }) => _id === payment.domain)
+    const company = realEstates.find(({ _id }) => _id === payment.company)
+    const defaultDateFormat = dateToDefaultFormat(
+      payment.invoiceCreationDate.toString()
+    )
+
+    await mockLoginAs(users.globalAdmin)
+
+    const mockReq = {
+      method: 'POST',
+      body: {
+        domainId: domain?._id,
+        companyId: company?._id,
+        to: ['ligos36529@cmheia.com'],
+        subject: `Оплата від ${defaultDateFormat}`,
+        text: `Ви отримали новий рахунок від "${payment.domain}" за ${defaultDateFormat}`,
+        // html: await generateHtmlFromThemplate(payment),
+      },
+    } as any
+    const mockRes = {
+      status: jest.fn(() => mockRes),
+      json: jest.fn(),
+    } as any
+
+    await handler(mockReq, mockRes)
+    Roles.ADMIN
+
+    const response = {
+      status: mockRes.status,
+      data: mockRes.json.mock.lastCall[0].data,
+    }
+
+    expect(response.status).toHaveBeenCalledWith(201)
+  })
+
+  it('should NOT send email as User - restricted access', async () => {
+    const payment = payments.find(
+      ({ _id }) => _id === '64d68421d9ba2fc8fea79d63'
+    )
+    const domain = domains.find(({ _id }) => _id === payment.domain)
+    const company = realEstates.find(({ _id }) => _id === payment.company)
+    const defaultDateFormat = dateToDefaultFormat(
+      payment.invoiceCreationDate.toString()
+    )
+
+    await mockLoginAs(users.user)
+
+    const mockReq = {
+      method: 'POST',
+      body: {
+        domainId: domain?._id,
+        companyId: company?._id,
+        to: ['ligos36529@cmheia.com'],
+        subject: `Оплата від ${defaultDateFormat}`,
+        text: `Ви отримали новий рахунок від "${payment.domain}" за ${defaultDateFormat}`,
+        // html: await generateHtmlFromThemplate(payment),
+      },
+    } as any
+    const mockRes = {
+      status: jest.fn(() => mockRes),
+      json: jest.fn(),
+    } as any
+
+    await handler(mockReq, mockRes)
+
+    const response = {
+      status: mockRes.status,
+      data: mockRes.json.mock.lastCall[0].data,
+    }
+
+    expect(response.status).toHaveBeenCalledWith(400)
+  })
+
+  it('should NOT send email without Role - restricted access', async () => {
+    const payment = payments.find(
+      ({ _id }) => _id === '64d68421d9ba2fc8fea79d63'
+    )
+    const domain = domains.find(({ _id }) => _id === payment.domain)
+    const company = realEstates.find(({ _id }) => _id === payment.company)
+    const defaultDateFormat = dateToDefaultFormat(
+      payment.invoiceCreationDate.toString()
+    )
+
+    await mockLoginAs(users.noRoleUser)
+
+    const mockReq = {
+      method: 'POST',
+      body: {
+        domainId: domain?._id,
+        companyId: company?._id,
+        to: ['ligos36529@cmheia.com'],
+        subject: `Оплата від ${defaultDateFormat}`,
+        text: `Ви отримали новий рахунок від "${payment.domain}" за ${defaultDateFormat}`,
+        // html: await generateHtmlFromThemplate(payment),
+      },
+    } as any
+    const mockRes = {
+      status: jest.fn(() => mockRes),
+      json: jest.fn(),
+    } as any
+
+    await handler(mockReq, mockRes)
+
+    const response = {
+      status: mockRes.status,
+      data: mockRes.json.mock.lastCall[0].data,
+    }
+
+    expect(response.status).toHaveBeenCalledWith(400)
+  })
+
+  it('should NOT send email as DomainAdmin of another domain - restricted access', async () => {
+    const payment = payments.find(
+      ({ _id }) => _id === '64d68421d9ba2fc8fea79d63'
+    )
+    const domain = domains.find(({ _id }) => _id === payment.domain)
+    const company = realEstates.find(({ _id }) => _id === payment.company)
+    const defaultDateFormat = dateToDefaultFormat(
+      payment.invoiceCreationDate.toString()
+    )
+
+    await mockLoginAs({
+      email: 'random.domain.admin.email@gmail.com',
+      roles: [Roles.DOMAIN_ADMIN],
+    })
+
+    const mockReq = {
+      method: 'POST',
+      body: {
+        domainId: domain?._id,
+        companyId: company?._id,
+        to: ['ligos36529@cmheia.com'],
+        subject: `Оплата від ${defaultDateFormat}`,
+        text: `Ви отримали новий рахунок від "${payment.domain}" за ${defaultDateFormat}`,
+        // html: await generateHtmlFromThemplate(payment),
+      },
+    } as any
+    const mockRes = {
+      status: jest.fn(() => mockRes),
+      json: jest.fn(),
+    } as any
+
+    await handler(mockReq, mockRes)
+
+    const response = {
+      status: mockRes.status,
+      data: mockRes.json.mock.lastCall[0].data,
+    }
+
+    expect(response.status).toHaveBeenCalledWith(400)
+  })
+})


### PR DESCRIPTION
API enpoint adaptation to role access rules:

- `User` and `Roleless` can't send emails
- `DomainAdmin` can send emails to companies of their domain
- `GlobalAdmin` can send emails to anyone

Jest unit tests for described scenarious included:

- should send email as `DomainAdmin`
- should send email as `GlobalAdmin`
- should send email as `GlobalAdmin` of another domain
- should NOT send email as `User`
- should NOT send email without `Role`
- should NOT send email as `DomainAdmin` of another domain