### PR TITLE
Remove browser open command

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "npm run browser:open && next dev",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "test:e2e": "playwright test",


### PR DESCRIPTION
This commit removes the `npm run browser:open` command from the `dev` script in `package.json`, which was previously causing issues with the development flow.

The automatic browser launch was causing delays and errors, as it attempted to execute a shell script that was unreliable across different environments. By removing this step, the `yarn dev` command now simply starts the Next.js development server without opening a browser.

Developers can manually open the browser and navigate to http://localhost:3000 or hover on it with command/ctrl, which simplifies and speeds up the development process.