### PR TITLE
Hide "Add Service" button in view-only mode

### DIFF
--- a/common/components/UI/DomainsComponents/DomainModal/DomainForm/DomainsServices/index.tsx
+++ b/common/components/UI/DomainsComponents/DomainModal/DomainForm/DomainsServices/index.tsx
@@ -42,15 +42,16 @@ const DomainsServices: FC<Props> = ({ editable }) => {
                 </Form.Item>
               </Card>
             ))}
-            <Button
-              disabled={!editable}
-              type="dashed"
-              style={{ marginBottom: 10 }}
-              onClick={() => add()}
-              block
-            >
-              + Додати послугу
-            </Button>
+            {editable && (
+              <Button
+                type="dashed"
+                style={{ marginBottom: 10 }}
+                onClick={() => add()}
+                block
+              >
+                + Додати послугу
+              </Button>
+            )}
           </div>
         )}
       </Form.List>


### PR DESCRIPTION
Conditionally render the "Add Service" button based on the `editable` prop. Button is now hidden when `editable` is false, ensuring proper view-only mode behavior