### PR TITLE
Fixing the order of filters

### DIFF
--- a/common/components/UI/PaymentCascader/index.jsx
+++ b/common/components/UI/PaymentCascader/index.jsx
@@ -22,7 +22,7 @@ const customOptions = [
   {
     label: 'Рік',
     value: 'year',
-    children: cascaderYears.map((year) => {
+    children: [...cascaderYears].reverse().map((year) => {
       return {
         label: year,
         value: year,


### PR DESCRIPTION
A shallow copy of the array is reversed to preserve the original data.

No changes were made to the filtering logic — only the display order was adjusted.

