### PR TITLE
Bump mongoose from 7.8.2 to 7.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lottie-react": "^2.4.1",
     "mockingoose": "^2.16.2",
     "mongodb": "^4.16.0",
-    "mongoose": "^7.4.2",
+    "mongoose": "^7.8.4",
     "next": "^13.4.19",
     "next-auth": "^4.23.1",
     "next-pwa": "^5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8308,10 +8308,10 @@ mongoose@*:
     ms "2.1.3"
     sift "17.1.3"
 
-mongoose@^7.4.2:
-  version "7.8.2"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-7.8.2.tgz#578e4d0b0b60421459399cfc47cab2a43d90155f"
-  integrity sha512-/KDcZL84gg8hnmOHRRPK49WtxH3Xsph38c7YqvYPdxEB2OsDAXvwAknGxyEC0F2P3RJCqFOp+523iFCa0p3dfw==
+mongoose@^7.8.4:
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-7.8.7.tgz#7a7ccbfd3da25990c88a8c41cd5b5abc30b913c7"
+  integrity sha512-5Bo4CrUxrPITrhMKsqUTOkXXo2CoRC5tXxVQhnddCzqDMwRXfyStrxj1oY865g8gaekSBhxAeNkYyUSJvGm9Hw==
   dependencies:
     bson "^5.5.0"
     kareem "2.5.1"


### PR DESCRIPTION
Bump mongoose from 7.8.2 to 7.8.4 (#941)
Bumps [mongoose](https://github.com/Automattic/mongoose) from 7.8.2 to 7.8.4.
- [Release notes](https://github.com/Automattic/mongoose/releases)
- [Changelog](https://github.com/Automattic/mongoose/blob/master/CHANGELOG.md)
- [Commits](Automattic/mongoose@7.8.2...7.8.4)

---
updated-dependencies:
- dependency-name: mongoose
  dependency-version: 7.8.4
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>