### PR TITLE
fix dropdown error on payments page

### DIFF
--- a/common/components/UI/PaymentCardHeader/index.tsx
+++ b/common/components/UI/PaymentCardHeader/index.tsx
@@ -222,6 +222,7 @@ const getItems = (panelStyle: React.CSSProperties): CollapseProps['items'] => [
     label,
     style: panelStyle,
     collapsible: 'icon',
+    forceRender: true,
     children: (
       <>
         <Divider className={styles.Divider}/>


### PR DESCRIPTION
fixed a bug where the view and edit buttons were not rendered before opening the collapse