### PR TITLE
Fix tooltip display formatting in domain table

### DIFF
--- a/common/components/Tables/Domains/Table.tsx
+++ b/common/components/Tables/Domains/Table.tsx
@@ -113,11 +113,14 @@ const getDefaultColumns = (
     title: 'Опис',
     dataIndex: 'description',
     width: 100,
-    render: (text) => (
-      <Tooltip title={text}>
-        <QuestionCircleOutlined />
-      </Tooltip>
-    ),
+     render: (text) => (
+    <Tooltip
+      title={<div style={{ whiteSpace: 'pre-line', maxWidth: 300 }}>{text}</div>}
+      overlayStyle={{ maxWidth: 800 }}
+    >
+      <QuestionCircleOutlined />
+    </Tooltip>
+  ),
   },
   {
     align: 'center',


### PR DESCRIPTION
Used pre-wrap and overlayStyle to handle multiline text in tooltip.