### PR TITLE
fix: hide receipt tab for credit payments

### DIFF
--- a/common/components/AddPaymentModal/index.tsx
+++ b/common/components/AddPaymentModal/index.tsx
@@ -191,19 +191,18 @@ const AddPaymentModal: FC<Props> = ({
     })
   }
 
-  if (!preview || paymentData?.type === Operations.Debit) {
-    items.push({
-      key: '4',
-      label: 'Довідка',
-      disabled: !shouldTabsEnabled,
-      children: (
-        <ReceiptForm
-          currPayment={currPayment}
-          paymentData={paymentData}
-          paymentActions={paymentActions}
-        />
-      ),
-    })
+  const operation = Form.useWatch('operation', form) 
+  if (!preview && operation !== Operations.Credit) { 
+    items.push({ 
+      key: '4', 
+      label: 'Довідка', 
+      disabled: !shouldTabsEnabled, 
+      children: ( 
+      <ReceiptForm 
+      currPayment={currPayment} 
+      paymentData={paymentData} 
+      paymentActions={paymentActions} /> ), 
+    }) 
   }
 
   const handleChange = () => {

--- a/common/components/AddPaymentModal/index.tsx
+++ b/common/components/AddPaymentModal/index.tsx
@@ -191,19 +191,27 @@ const AddPaymentModal: FC<Props> = ({
     })
   }
 
-  const operation = Form.useWatch('operation', form) 
-  if (!preview && operation !== Operations.Credit) { 
-    items.push({ 
-      key: '4', 
-      label: 'Довідка', 
-      disabled: !shouldTabsEnabled, 
-      children: ( 
-      <ReceiptForm 
-      currPayment={currPayment} 
-      paymentData={paymentData} 
-      paymentActions={paymentActions} /> ), 
-    }) 
-  }
+  const operation = Form.useWatch('operation', form)
+
+const effectiveOperation = preview
+  ? paymentData?.type
+  : operation
+
+  if (effectiveOperation === Operations.Debit) {
+  items.push({
+    key: '4',
+    label: 'Довідка',
+    disabled: !shouldTabsEnabled,
+    children: (
+      <ReceiptForm
+        currPayment={currPayment}
+        paymentData={paymentData}
+        paymentActions={paymentActions}
+      />
+    ),
+  })
+}
+
 
   const handleChange = () => {
     setSaved(false)


### PR DESCRIPTION
The Help tab is hidden for the credit account type.