### PR TITLE
move payment changelog mutations to separate changelogApi

### DIFF
--- a/common/api/changelogApi/changelog.api.ts
+++ b/common/api/changelogApi/changelog.api.ts
@@ -1,0 +1,48 @@
+import { paymentApi } from '../paymentApi/payment.api';
+import { 
+  ICreatePaymentChangeLogResponse, 
+  IDeletePaymentChangeLogResponse, 
+  IGetPaymentChangeLogsResponse 
+} from '../paymentApi/payment.api.types';
+
+export const changelogApi = paymentApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getPaymentChangeLogs: builder.query<IGetPaymentChangeLogsResponse, string>({
+      query: (paymentId) => `spacehub/payment/${paymentId}/change-log`,
+      providesTags: (res, err, paymentId) =>
+        res ? [{ type: 'Payment', id: paymentId }] : [],
+    }),
+
+    createPaymentChangeLog: builder.mutation<
+      ICreatePaymentChangeLogResponse,
+      { paymentId: string; invoiceData: any; reason?: string }
+    >({
+      query: ({ paymentId, ...body }) => ({
+        url: `spacehub/payment/${paymentId}/change-log`,
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: (res, err, args) =>
+        res ? [{ type: 'Payment', id: args.paymentId }] : [],
+    }),
+
+    deletePaymentChangeLog: builder.mutation<
+      IDeletePaymentChangeLogResponse,
+      { paymentId: string; changeLogid: string }
+    >({
+      query: ({ paymentId, changeLogid }) => ({
+        url: `spacehub/payment/${paymentId}/change-log?changeLogId=${changeLogid}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: (res, err, args) =>
+        res ? [{ type: 'Payment', id: args.paymentId }] : [],
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const {
+  useGetPaymentChangeLogsQuery,
+  useCreatePaymentChangeLogMutation,
+  useDeletePaymentChangeLogMutation,
+} = changelogApi;

--- a/common/api/paymentApi/payment.api.ts
+++ b/common/api/paymentApi/payment.api.ts
@@ -14,9 +14,6 @@ import {
   IGeneratePaymentExcelResponce,
   IAddCostPaymentResponse,
   ICostPayment,
-  IGetPaymentChangeLogsResponse,
-  ICreatePaymentChangeLogResponse,
-  IDeletePaymentChangeLogResponse,
 } from './payment.api.types'
 import { ITransaction } from '@components/Pages/BankTransactions/components/TransactionsTable/components/transactionTypes'
 
@@ -171,36 +168,6 @@ export const paymentApi = createApi({
         body,
       }),
     }),
-    getPaymentChangeLogs: builder.query<IGetPaymentChangeLogsResponse, string>({
-      query: (paymentId) => `spacehub/payment/${paymentId}/change-log`,
-      providesTags: (res, err, paymentId) =>
-        res ? [{ type: 'Payment', id: paymentId }] : [],
-    }),
-
-    createPaymentChangeLog: builder.mutation<
-      ICreatePaymentChangeLogResponse,
-      { paymentId: string; invoiceData: any; reason?: string }
-    >({
-      query: ({ paymentId, ...body }) => ({
-        url: `spacehub/payment/${paymentId}/change-log`,
-        method: 'POST',
-        body,
-      }),
-      invalidatesTags: (res, err, args) =>
-        res ? [{ type: 'Payment', id: args.paymentId }] : [],
-    }),
-
-    deletePaymentChangeLog: builder.mutation<
-      IDeletePaymentChangeLogResponse,
-      { paymentId: string; changeLogid: string }
-    >({
-      query: ({paymentId, changeLogid}) => ({
-        url: `spacehub/payment/${paymentId}/change-log?changeLogId=${changeLogid}`,
-        method: 'DELETE',
-      }),
-      invalidatesTags: (res, err, args) =>
-        res ? [{ type: 'Payment', id: args.paymentId }] : [],
-    }),
   }),
 })
 export const {
@@ -215,7 +182,4 @@ export const {
   useGetCostPaymentQuery,
   useAddCostPaymentMutation,
   useGenerateExcelMutation,
-  useGetPaymentChangeLogsQuery,
-  useCreatePaymentChangeLogMutation,
-  useDeletePaymentChangeLogMutation
 } = paymentApi

--- a/common/components/AddPaymentModal/index.tsx
+++ b/common/components/AddPaymentModal/index.tsx
@@ -2,8 +2,11 @@ import { useGetCustomServicesByDomainQuery } from '@common/api/customServicesApi
 import {
   useAddPaymentMutation,
   useEditPaymentMutation,
-  useDeletePaymentChangeLogMutation,
 } from '@common/api/paymentApi/payment.api'
+import { 
+  useGetPaymentChangeLogsQuery, 
+  useDeletePaymentChangeLogMutation 
+} from '@common/api/changelogApi/changelog.api'
 import {
   IExtendedPayment,
   IPayment,
@@ -18,7 +21,6 @@ import { getInvoices } from '@utils/getInvoices'
 import { getPaymentProviderAndReciever } from '@utils/helpers'
 import { Form, Tabs, TabsProps, message, Tooltip } from 'antd'
 import { FormInstance } from 'antd/es/form/Form'
-import { useGetPaymentChangeLogsQuery } from '@common/api/paymentApi/payment.api'
 import { useChangelogOptions } from './changelog/useChangelogOptions'
 import dayjs from 'dayjs'
 import {

--- a/pages/api/custom-services/index.test.ts
+++ b/pages/api/custom-services/index.test.ts
@@ -1,0 +1,122 @@
+import { expect } from '@jest/globals'
+import { mockLoginAs } from '@utils/mockLoginAs'
+import { setupTestEnvironment } from '@utils/setupTestEnvironment'
+import handler from '@pages/api/custom-services/index'
+import CustomService from '@modules/models/CustomService'
+import { users } from '@utils/testData'
+
+jest.mock('next-auth', () => ({ getServerSession: jest.fn() }))
+jest.mock('@pages/api/auth/[...nextauth]', () => ({ authOptions: {} }))
+jest.mock('@pages/api/api.config', () => jest.fn())
+jest.mock('@modules/models/CustomService')
+
+setupTestEnvironment()
+
+describe('CustomServices API', () => {
+  
+  const createMocks = (method: string, { body = {}, query = {} } = {}) => {
+    const req = { method, body, query } as any
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    } as any
+    return { req, res }
+  }
+
+  describe('POST /api/custom-services (Validation & Safety)', () => {
+    
+    test.each([
+      ['undefined', {}],
+      ['null', { name: null }],
+      ['empty string', { name: '' }],
+      ['just spaces', { name: '   ' }],
+    ])('should return 400 if name is %s', async (_, body) => {
+      await mockLoginAs(users.globalAdmin)
+      const { req, res } = createMocks('POST', { body })
+
+      await handler(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Назва послуги не може бути порожньою' })
+      )
+    })
+
+    it('should escape regex characters to prevent ReDoS or bypass', async () => {
+      await mockLoginAs(users.globalAdmin)
+      const spicyName = 'Service.*'
+      const { req, res } = createMocks('POST', { body: { name: spicyName } })
+
+      ;(CustomService.findOne as jest.Mock).mockResolvedValue(null)
+      ;(CustomService.create as jest.Mock).mockResolvedValue({
+        name: spicyName,
+        toObject: () => ({ name: spicyName })
+      })
+
+      await handler(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(201)
+      expect(CustomService.findOne).toHaveBeenCalledWith({
+        name: { $regex: '^Service\\.\\*$', $options: 'i' }
+      })
+    })
+  })
+
+  describe('DELETE /api/custom-services (Access Control)', () => {
+    
+    it('should strictly deny access for DomainAdmin (403)', async () => {
+      await mockLoginAs(users.domainAdmin)
+      const { req, res } = createMocks('DELETE', { query: { id: 'some-id' } })
+
+      await handler(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(403)
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false })
+      )
+    })
+
+    it('should return 400 for malformed or missing IDs', async () => {
+      await mockLoginAs(users.globalAdmin)
+      const { req, res } = createMocks('DELETE', { query: { id: ['', 'array'] } as any })
+
+      await handler(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(400)
+    })
+  })
+
+  describe('GET /api/custom-services (Data Retrieval)', () => {
+    
+    it('should return 400 for regular Users (No access allowed)', async () => {
+      await mockLoginAs(users.user)
+      const { req, res } = createMocks('GET')
+
+      await handler(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Не дозволено' })
+      )
+    })
+
+it('should handle multi-ID filtering via query string', async () => {
+      await mockLoginAs(users.domainAdmin)
+      const ids = '64d68421d9ba2fc8fea79d14,64d68421d9ba2fc8fea79d15'
+      const { req, res } = createMocks('GET', { query: { _id: ids } })
+
+      const mockFindChain = {
+        lean: jest.fn().mockResolvedValue([{ name: 'Service 1' }, { name: 'Service 2' }])
+      };
+      (CustomService.find as jest.Mock).mockReturnValue(mockFindChain);
+
+      await handler(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      
+      expect(CustomService.find).toHaveBeenCalledWith({
+        _id: { $in: ['64d68421d9ba2fc8fea79d14', '64d68421d9ba2fc8fea79d15'] }
+      })
+    })
+  })
+})


### PR DESCRIPTION
Створено новий файл common/api/changelogApi/changelog.api.ts.

Перенесено ендпоінти та відповідні хуки (useCreatePaymentChangeLogMutation, useDeletePaymentChangeLogMutation, useGetPaymentChangeLogsQuery) з payment.api.ts за допомогою методу .injectEndpoints().

Очищено payment.api.ts від зайвої логіки логів.

Оновлено імпорти в компоненті AddPaymentModal/index.tsx та інших місцях використання, що виправило помилку TypeError: ... is not a function.