### PR TITLE
Dev

### DIFF
--- a/common/api/realestateApi/realestate.api.ts
+++ b/common/api/realestateApi/realestate.api.ts
@@ -22,10 +22,11 @@ export const realestateApi = createApi({
         domainId?: string[] | string
         streetId?: string[] | string
         companyId?: string[] | string
+        services?: string[] | string
         archived?: boolean
       }
     >({
-      query: ({ limit, companyId, domainId, streetId, archived }) => {
+      query: ({ limit, companyId, domainId, streetId, archived, services }) => {
         return {
           url: `real-estate`,
           params: {
@@ -34,6 +35,7 @@ export const realestateApi = createApi({
             domainId,
             streetId,
             archived,
+            services,
           },
         }
       },

--- a/common/components/AddPaymentModal/index.tsx
+++ b/common/components/AddPaymentModal/index.tsx
@@ -92,6 +92,7 @@ const AddPaymentModal: FC<Props> = ({
   const [form] = Form.useForm()
   const firstRunRef = useRef(true)
   const restoringRef = useRef(false)
+  const lastLoadedCompanyId = useRef<string | null>(null);
   const [changed, setChanged] = useState(false)
   const [saved, setSaved] = useState(false)
   const [currPayment, setCurrPayment] = useState<IExtendedPayment>()
@@ -159,6 +160,16 @@ const AddPaymentModal: FC<Props> = ({
     const allowedServices = groups.flatMap((group) => group.services)
 
     const serviceFilteredInvoices = serviceFilter(allInvoices, allowedServices)
+    const hasDiscount = serviceFilteredInvoices.some(inv => inv.type === 'discount')
+  
+  if (!hasDiscount && company?.discount) {
+    serviceFilteredInvoices.push({
+      type: 'discount',
+      name: 'Знижка',
+      price: company.discount,
+      sum: company.discount,
+    })
+  }
 
     return serviceFilteredInvoices?.filter(
       (invoice) => invoice?.sum > 0 || DEFAULT_INVOICES.includes(invoice?.type)
@@ -333,9 +344,21 @@ const AddPaymentModal: FC<Props> = ({
   }
 
   useEffect(() => {
-    if (activeTabKey !== '1' || saved) return
-    form.setFieldsValue({ invoice: filteredInvoices })
-  }, [filteredInvoices, saved, activeTabKey, form])
+    if (activeTabKey !== '1' || saved || !company || !company._id) return
+  const isEditing = !!paymentId || edit; 
+
+  if (isEditing) {
+    lastLoadedCompanyId.current = company._id;
+    return;
+  }
+
+  const isNewCompanySelected = lastLoadedCompanyId.current !== company._id;
+
+  if (isNewCompanySelected) {
+    form.setFieldsValue({ invoice: filteredInvoices });
+    lastLoadedCompanyId.current = company._id;
+  }
+  }, [company, filteredInvoices, paymentId, edit, activeTabKey, saved, form])
 
   return (
     <PaymentContext.Provider
@@ -372,7 +395,9 @@ const AddPaymentModal: FC<Props> = ({
             street: getId(payment?.street),
             company: preselectedCompany || getId(payment?.company),
             monthService: getId(payment?.monthService),
-            invoice: payment?.invoice || filteredInvoices,
+            invoice: (payment?.invoice && payment.invoice.length > 0) 
+              ? payment.invoice 
+              : filteredInvoices,
             description: payment?.description,
             generalSum: payment?.generalSum,
             invoiceNumber: payment?.invoiceNumber,

--- a/common/components/AddPaymentModal/index.tsx
+++ b/common/components/AddPaymentModal/index.tsx
@@ -279,7 +279,7 @@ const AddPaymentModal: FC<Props> = ({
     const values = await form.validateFields()
 
     if (values.operation === Operations.Credit) {
-      handleSubmit()
+      await handleSubmit()
       return
     }
 
@@ -297,7 +297,13 @@ const AddPaymentModal: FC<Props> = ({
       street: formData.street,
       company: formData.company,
       monthService: formData.monthService,
-      invoiceCreationDate: formData.invoiceCreationDate,
+      invoiceCreationDate: formData.invoiceCreationDate
+        ? new Date(Date.UTC(
+            formData.invoiceCreationDate.year(),
+            formData.invoiceCreationDate.month(),
+            formData.invoiceCreationDate.date()
+          ))
+        : null,
       description: formData.description || '',
       generalSum: formData.generalSum || formData.debit,
       provider,

--- a/common/components/DashboardPage/blocks/payments.tsx
+++ b/common/components/DashboardPage/blocks/payments.tsx
@@ -216,6 +216,7 @@ const PaymentsBlock: React.FC<PaymentsBlockProps> = ({ sepDomainID }) => {
         setFilters({
           ...allFilters,
           invoiceCreationDate: invoiceVals,
+          street: filters?.street,
         })
       )
     }

--- a/common/components/DashboardPage/blocks/realEstates.tsx
+++ b/common/components/DashboardPage/blocks/realEstates.tsx
@@ -47,6 +47,7 @@ const RealEstateBlock: React.FC<Props> = ({
       domainId: sepDomainID || domainId || filters?.domain || undefined,
       companyId: filters?.company || undefined,
       streetId: streetId || filters?.street || undefined,
+      services: filters?.services || undefined,
       limit: isOnPage ? 0 : 5,
       archived: isArchive,
     },
@@ -93,7 +94,7 @@ const RealEstateBlock: React.FC<Props> = ({
         realEstateActions={realEstateActions}
         setRealEstateActions={setRealEstateActions}
         isArchive={isArchive}
-        customServices={customServicesData?.data}
+        customServices={customServicesData?.data || []}
       />
     </TableCard>
   )

--- a/common/components/DashboardPage/dashboard.test.ts
+++ b/common/components/DashboardPage/dashboard.test.ts
@@ -1,0 +1,134 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+
+const ALL_WIDGET_IDS = ['payments', 'paymentsChart', 'services', 'streets', 'domain', 'realEstate', 'profits', 'companies']
+
+function TestDashboard({ userId = 'user-123' }: { userId?: string }) {
+  const [ordered, setOrdered] = React.useState<string[]>([...ALL_WIDGET_IDS])
+  const [hidden, setHidden] = React.useState<string[]>([])
+
+  React.useEffect(() => {
+    const key = `dashboard-layout-${userId}`
+    const raw = localStorage.getItem(key)
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw)
+        setOrdered(parsed.layout ?? ALL_WIDGET_IDS)
+        setHidden(parsed.hidden ?? [])
+      } catch {}
+    }
+  }, [userId])
+
+  const save = () => {
+    const key = `dashboard-layout-${userId}`
+    localStorage.setItem(key, JSON.stringify({ layout: ordered, hidden }))
+  }
+
+  const move = (id: string, toIndex: number) => {
+    setOrdered((prev) => {
+      const from = prev.indexOf(id)
+      if (from === -1) return prev
+      const copy = [...prev]
+      copy.splice(from, 1)
+      copy.splice(toIndex, 0, id)
+      return copy
+    })
+  }
+
+  const toggleHidden = (id: string) =>
+    setHidden((prev) => (prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id]))
+
+  return React.createElement(
+    'div',
+    null,
+    React.createElement(
+      'div',
+      null,
+      React.createElement('button', { 'aria-label': 'save', onClick: save }, 'Зберегти'),
+      React.createElement('button', { 'aria-label': 'visibility-menu' }, 'Приховати'),
+      React.createElement(
+        'div',
+        { 'data-testid': 'visibility-menu' },
+        ...ALL_WIDGET_IDS.map((id) =>
+          React.createElement(
+            'button',
+            { key: id, 'data-testid': `toggle-${id}`, onClick: () => toggleHidden(id) },
+            hidden.includes(id) ? `Показати ${id}` : `Сховати ${id}`
+          )
+        )
+      )
+    ),
+    React.createElement(
+      'div',
+      null,
+      ...(ordered.filter((id) => !hidden.includes(id)).map((id, idx) =>
+        React.createElement(
+          'div',
+          { key: id, id, 'data-testid': `widget-${id}` },
+          React.createElement('span', null, id),
+          React.createElement('button', { 'data-testid': `move-up-${id}`, onClick: () => move(id, Math.max(0, idx - 1)) }, 'up'),
+          React.createElement('button', { 'data-testid': `move-down-${id}`, onClick: () => move(id, Math.min(ALL_WIDGET_IDS.length - 1, idx + 1)) }, 'down')
+        )
+      ))
+    )
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('Dashboard — basic behaviors', () => {
+  it('Всі таблиці: рендерить усі 8 віджетів за замовчуванням', async () => {
+    render(React.createElement(TestDashboard))
+    await waitFor(() => {
+      ALL_WIDGET_IDS.forEach((id) => expect(screen.getByTestId(`widget-${id}`)).toBeInTheDocument())
+    })
+  })
+
+  it('Обробка переміщень таблиць: змінює порядок і зберігає його', async () => {
+    const user = userEvent.setup()
+    render(React.createElement(TestDashboard))
+    await user.click(screen.getByTestId('move-down-payments'))
+    await user.click(screen.getByRole('button', { name: 'save' }))
+
+    const raw = localStorage.getItem('dashboard-layout-user-123')
+    expect(raw).not.toBeNull()
+    const saved = JSON.parse(raw!)
+    expect(Array.isArray(saved.layout)).toBe(true)
+    expect(saved.layout[0]).not.toBe('payments')
+  })
+
+  it('Збереження у local Storage: зберігає layout і hidden', async () => {
+    const user = userEvent.setup()
+    render(React.createElement(TestDashboard))
+    await user.click(screen.getByTestId('toggle-streets'))
+    await user.click(screen.getByRole('button', { name: 'save' }))
+
+    const raw = localStorage.getItem('dashboard-layout-user-123')
+    expect(raw).not.toBeNull()
+    const saved = JSON.parse(raw!)
+    expect(saved).toHaveProperty('layout')
+    expect(saved).toHaveProperty('hidden')
+    expect(saved.hidden).toContain('streets')
+  })
+
+  it('Приховання таблиць: ховає віджет після вибору у меню видимості', async () => {
+    const user = userEvent.setup()
+    render(React.createElement(TestDashboard))
+    expect(screen.getByTestId('widget-payments')).toBeInTheDocument()
+    await user.click(screen.getByTestId('toggle-payments'))
+    await waitFor(() => expect(screen.queryByTestId('widget-payments')).not.toBeInTheDocument())
+  })
+
+  it('Відображення таблиць після приховання: показує віджет знову після повторного кліку', async () => {
+    const user = userEvent.setup()
+    render(React.createElement(TestDashboard))
+    await user.click(screen.getByTestId('toggle-services'))
+    await waitFor(() => expect(screen.queryByTestId('widget-services')).not.toBeInTheDocument())
+    await user.click(screen.getByTestId('toggle-services'))
+    await waitFor(() => expect(screen.getByTestId('widget-services')).toBeInTheDocument())
+  })
+})

--- a/common/components/Forms/AddPaymentForm/PaymentPricesTable/fields/sum/Unknown.tsx
+++ b/common/components/Forms/AddPaymentForm/PaymentPricesTable/fields/sum/Unknown.tsx
@@ -1,9 +1,16 @@
 import { IPaymentField } from '@common/api/paymentApi/payment.api.types'
+import { usePaymentContext } from '@components/AddPaymentModal'
+import { getCurrencySymbol } from '@utils/helpers'
 
 const Unknown: React.FC<{
   record: IPaymentField & { key: string }
 }> = ({ record }) => {
-  return <>0 грн</>
+  const { form } = usePaymentContext()
+  const company = form.getFieldValue('company')
+  const domain = form.getFieldValue('domain')
+  const currencyLabel = getCurrencySymbol(company?.currency || domain?.currency)
+
+  return <>0 {currencyLabel}</>
 }
 
 export default Unknown

--- a/common/components/Forms/AddPaymentForm/PaymentPricesTable/fields/sum/index.tsx
+++ b/common/components/Forms/AddPaymentForm/PaymentPricesTable/fields/sum/index.tsx
@@ -1,6 +1,6 @@
 import { IPaymentField } from '@common/api/paymentApi/payment.api.types'
 import { usePaymentContext } from '@components/AddPaymentModal'
-import { toRoundFixed } from '@utils/helpers'
+import { getCurrencySymbol, toRoundFixed } from '@utils/helpers'
 import { useEffect } from 'react'
 
 export { default as Cleaning } from './Cleaning'
@@ -19,6 +19,9 @@ export const Sum: React.FC<{
   record: IPaymentField & { key: string }
 }> = ({ record }) => {
   const { form } = usePaymentContext()
+  const company = form.getFieldValue('company')
+  const domain = form.getFieldValue('domain')
+  const currencyLabel = getCurrencySymbol(company?.currency || domain?.currency)
 
   const { lastAmount, amount, price } = record
 
@@ -40,5 +43,9 @@ export const Sum: React.FC<{
     record.lastAmount,
   ])
 
-  return <>{toRoundFixed(record.sum)} грн</>
+  return (
+    <>
+      {toRoundFixed(record.sum)} {currencyLabel}
+    </>
+  )
 }

--- a/common/components/Forms/AddPaymentForm/PaymentTotal.tsx
+++ b/common/components/Forms/AddPaymentForm/PaymentTotal.tsx
@@ -1,4 +1,6 @@
 import { Operations } from '@utils/constants'
+import { getCurrencySymbol } from '@utils/helpers'
+import { usePaymentContext } from '@components/AddPaymentModal'
 import { Form, FormInstance } from 'antd'
 import { FC, useEffect } from 'react'
 
@@ -7,8 +9,10 @@ interface Props {
 }
 
 const PaymentTotal: FC<Props> = ({ form }) => {
+  const { company } = usePaymentContext()
   const invoices = Form.useWatch(['invoice'], form)
   const total = Form.useWatch(Operations.Debit, form)
+  const currencyLabel = getCurrencySymbol(company?.currency)
 
   useEffect(() => {
     const newTotal = Object.entries<{ sum: number }>(invoices || []).reduce(
@@ -30,7 +34,7 @@ const PaymentTotal: FC<Props> = ({ form }) => {
       name={Operations.Debit}
       initialValue={0}
     >
-      <>Сума: {(+total)?.toFixed(2)} ₴</>
+      <>Сума: {(+total)?.toFixed(2)} {currencyLabel}</>
     </Form.Item>
   )
 }

--- a/common/components/Forms/AddPaymentForm/PriceList/index.tsx
+++ b/common/components/Forms/AddPaymentForm/PriceList/index.tsx
@@ -5,6 +5,7 @@ import dayjs from 'dayjs'
 import styles from './styles.module.scss'
 import GroupedPricesTable from '@components/Forms/GroupedReceiptForm/GroupedPricesTable'
 import { IPayment } from '@common/api/paymentApi/payment.api.types'
+import { getCurrencyNames, normalizeCurrency } from '@utils/helpers'
 
 const PriceList: FC<{ data: IPayment }> = ({ data }) => {
   const [payment, setPayment] = useState(data)
@@ -23,13 +24,11 @@ const PriceList: FC<{ data: IPayment }> = ({ data }) => {
     setTotalFractionSum(Number(fraction))
   }, [payment])
 
-  useEffect(() => {
-    const sum = payment.invoice.reduce((acc, item) => acc + Number(item.sum), 0)
-    setTotalSum(sum)
-
-    const [, fraction] = sum.toFixed(2).split('.')
-    setTotalFractionSum(Number(fraction))
-  }, [payment])
+  const company = payment?.company as { currency?: string } | string | undefined
+  const companyCurrency = typeof company === 'object' ? company?.currency : undefined
+  const currency = companyCurrency || payment?.domain?.currency
+  const currencyNames = getCurrencyNames(currency)
+  const isEnglish = normalizeCurrency(currency) !== 'UAH'
 
   const componentRef = useRef()
   const handlePrint = useReactToPrint({
@@ -55,14 +54,14 @@ const PriceList: FC<{ data: IPayment }> = ({ data }) => {
             <div className={styles.approvalSectionWrapper}>
               <div className={styles.approvalSection}>
                 <div>
-                  <strong>ЗАТВЕРДЖУЮ</strong>
+                  <strong>{isEnglish ? 'APPROVED' : 'ЗАТВЕРДЖУЮ'}</strong>
                   <br />
                   <pre>{payment.provider.description?.trim()}</pre>
                 </div>
               </div>
               <div className={styles.approvalSection}>
                 <div>
-                  <strong>ЗАТВЕРДЖУЮ</strong>
+                  <strong>{isEnglish ? 'APPROVED' : 'ЗАТВЕРДЖУЮ'}</strong>
                   <br />
                   <pre>
                     {payment?.reciever?.description?.trim()} <br />
@@ -90,13 +89,14 @@ const PriceList: FC<{ data: IPayment }> = ({ data }) => {
 
           <div className={styles.titleSection}>
             <h1>
-              <b>АКТ надання послуг</b>
+              <b>{isEnglish ? 'SERVICE ACCEPTANCE ACT' : 'АКТ надання послуг'}</b>
             </h1>
             <p>
               <b>
-                № {payment?.invoiceNumber} від{' '}
-                {dayjs(payment?.invoiceCreationDate)?.format?.('DD.MM.YYYY')}{' '}
-                року.
+                {isEnglish ? 'No.' : '№'} {payment?.invoiceNumber}{' '}
+                {isEnglish ? 'dated' : 'від'}{' '}
+                {dayjs(payment?.invoiceCreationDate)?.format?.('DD.MM.YYYY')}
+                {isEnglish ? '.' : ' року.'}
               </b>
             </p>
             <br />
@@ -105,16 +105,35 @@ const PriceList: FC<{ data: IPayment }> = ({ data }) => {
 
           <div className={styles.contentSection}>
             <p>
-              Ми, що нижче підписалися, представник Замовника{' '}
-              {payment.reciever.description
-                ?.trim()
-                .replace(/(:\s)/g, ':\u00A0')}
-              , з одного боку, і представник Виконавця{' '}
-              {payment.provider.description
-                ?.trim()
-                .replace(/(:\s)/g, ':\u00A0')}
-              , з іншого боку, склали цей акт про те, що на підставі договору,
-              Виконавцем були виконані наступні роботи (надані такі послуги):
+              {isEnglish ? (
+                <>
+                  We, the undersigned, the representative of the Customer{' '}
+                  {payment.reciever.description
+                    ?.trim()
+                    .replace(/(:\s)/g, ':\u00A0')}
+                  , on one side, and the representative of the Provider{' '}
+                  {payment.provider.description
+                    ?.trim()
+                    .replace(/(:\s)/g, ':\u00A0')}
+                  , on the other side, have executed this Act confirming that,
+                  under the agreement, the Provider performed the following
+                  services:
+                </>
+              ) : (
+                <>
+                  Ми, що нижче підписалися, представник Замовника{' '}
+                  {payment.reciever.description
+                    ?.trim()
+                    .replace(/(:\s)/g, ':\u00A0')}
+                  , з одного боку, і представник Виконавця{' '}
+                  {payment.provider.description
+                    ?.trim()
+                    .replace(/(:\s)/g, ':\u00A0')}
+                  , з іншого боку, склали цей акт про те, що на підставі
+                  договору, Виконавцем були виконані наступні роботи (надані
+                  такі послуги):
+                </>
+              )}
             </p>
           </div>
 
@@ -122,6 +141,7 @@ const PriceList: FC<{ data: IPayment }> = ({ data }) => {
             <GroupedPricesTable
               preview
               domainId={payment?.domain?._id}
+              currency={currency}
               invoices={payment.invoice}
             />
           </div>
@@ -129,13 +149,33 @@ const PriceList: FC<{ data: IPayment }> = ({ data }) => {
           <div className={styles.contaiіner}>
             <div className={styles.contentSection}>
               <div>
-                Загальна вартість робіт (послуг) склала без ПДВ{' '}
-                {totalSum.toFixed(0)} гривень {totalFractionSum} копійок, ПДВ 0
-                гривень 00 копійок, загальна вартість робіт (послуг) із ПДВ{' '}
-                {totalSum.toFixed(0)} гривень {totalFractionSum} копійок.
-                <br />
-                Замовник претензій по об’єму, якості та строкам виконання робіт
-                (надання послуг) не має.
+                {isEnglish ? (
+                  <>
+                    The total cost of services excluding VAT is{' '}
+                    {totalSum.toFixed(0)} {currencyNames.major}{' '}
+                    {totalFractionSum} {currencyNames.minor}, VAT is 0{' '}
+                    {currencyNames.major} 00 {currencyNames.minor}, and the
+                    total cost including VAT is {totalSum.toFixed(0)}{' '}
+                    {currencyNames.major} {totalFractionSum}{' '}
+                    {currencyNames.minor}.
+                    <br />
+                    The Customer has no claims regarding the scope, quality, or
+                    timing of the provided services.
+                  </>
+                ) : (
+                  <>
+                    Загальна вартість робіт (послуг) склала без ПДВ{' '}
+                    {totalSum.toFixed(0)} {currencyNames.major}{' '}
+                    {totalFractionSum} {currencyNames.minor}, ПДВ 0{' '}
+                    {currencyNames.major} 00 {currencyNames.minor}, загальна
+                    вартість робіт (послуг) із ПДВ {totalSum.toFixed(0)}{' '}
+                    {currencyNames.major} {totalFractionSum}{' '}
+                    {currencyNames.minor}.
+                    <br />
+                    Замовник претензій по об’єму, якості та строкам виконання
+                    робіт (надання послуг) не має.
+                  </>
+                )}
               </div>
               <br />
             </div>
@@ -144,7 +184,7 @@ const PriceList: FC<{ data: IPayment }> = ({ data }) => {
             <div className={styles.signaturesSection}>
               <div className={styles.signatureBlock}>
                 <div>
-                  <b>Від Виконавця</b>
+                  <b>{isEnglish ? 'Provider' : 'Від Виконавця'}</b>
                   <br />
                   <br />
                   <hr />
@@ -158,7 +198,7 @@ const PriceList: FC<{ data: IPayment }> = ({ data }) => {
               </div>
               <div className={styles.signatureBlock}>
                 <div>
-                  <b>Від Замовника</b>
+                  <b>{isEnglish ? 'Customer' : 'Від Замовника'}</b>
                   <br />
                   <br />
                   <hr />

--- a/common/components/Forms/GroupedReceiptForm/GroupedPricesTable/index.tsx
+++ b/common/components/Forms/GroupedReceiptForm/GroupedPricesTable/index.tsx
@@ -2,28 +2,33 @@ import { usePaymentContext } from '@components/AddPaymentModal'
 import { useGetCustomServicesByDomainQuery } from '@common/api/customServicesApi/customServices.api'
 import { Table } from 'antd'
 import { useMemo } from 'react'
+import { getCurrencyShortLabel, normalizeCurrency } from '@utils/helpers'
 
 export interface PaymentPricesTableProps {
   preview?: boolean
   domainId?: string
+  currency?: string
   loading?: boolean
   invoices?: any[]
 }
 
-const columns = [
+const getColumns = (currency?: string) => [
   {
-    title: '№',
+    title: normalizeCurrency(currency) === 'UAH' ? '№' : 'No.',
     dataIndex: 'key',
     key: 'key',
     width: 45,
   },
   {
-    title: 'Найменування послуги',
+    title:
+      normalizeCurrency(currency) === 'UAH'
+        ? 'Найменування послуги'
+        : 'Service name',
     dataIndex: 'name',
     key: 'name',
   },
   {
-    title: 'Сума, грн',
+    title: `${normalizeCurrency(currency) === 'UAH' ? 'Сума' : 'Amount'}, ${getCurrencyShortLabel(currency)}`,
     dataIndex: 'sum',
     key: 'sum',
     render: (value: any) => {
@@ -65,10 +70,11 @@ const groupedInvoices = (invoices: any, groups: any) => {
 const GroupedPricesTable: React.FC<PaymentPricesTableProps> = ({
   preview,
   domainId,
+  currency,
   loading,
   invoices,
 }) => {
-  const { form } = usePaymentContext()
+  const { form, company } = usePaymentContext()
 
   const { data: customDomainServices } = useGetCustomServicesByDomainQuery(
     { domainId: [domainId] },
@@ -78,6 +84,8 @@ const GroupedPricesTable: React.FC<PaymentPricesTableProps> = ({
     () => groupedInvoices(invoices, customDomainServices?.data),
     [invoices, customDomainServices]
   )
+
+  const { domain } = form.getFieldsValue()
 
   const groupedFieldNames =
     groupedInvoicesData?.flatMap((group) => group.fieldNames || []) || []
@@ -89,10 +97,12 @@ const GroupedPricesTable: React.FC<PaymentPricesTableProps> = ({
       sum: group.totalSum,
     })) || []
   const discountInvoice = invoices?.find((inv) => inv?.type === 'discount')
+  const isEnglish = normalizeCurrency(currency || company?.currency || domain?.currency) !== 'UAH'
+
   if (discountInvoice) {
     dataSource.push({
       key: dataSource.length + 1,
-      name: 'Знижка',
+      name: isEnglish ? 'Discount' : 'Знижка',
       sum: discountInvoice.sum,
     })
   }
@@ -106,7 +116,7 @@ const GroupedPricesTable: React.FC<PaymentPricesTableProps> = ({
     !inv?.customService &&
       dataSource.push({
         key: dataSource.length + 1,
-        name: inv.name || 'Додатково',
+        name: inv.name || (isEnglish ? 'Additional' : 'Додатково'),
         sum: inv.sum,
       })
   })
@@ -114,7 +124,7 @@ const GroupedPricesTable: React.FC<PaymentPricesTableProps> = ({
   return (
     <Table
       dataSource={dataSource}
-      columns={columns}
+      columns={getColumns(currency || company?.currency || domain?.currency)}
       loading={loading}
       pagination={false}
       bordered

--- a/common/components/Forms/GroupedReceiptForm/index.tsx
+++ b/common/components/Forms/GroupedReceiptForm/index.tsx
@@ -4,7 +4,8 @@ import numberToTextNumber from '@utils/numberToText'
 import dayjs from 'dayjs'
 import { FC, useRef } from 'react'
 import { useReactToPrint } from 'react-to-print'
-import { PrinterOutlined } from '@ant-design/icons'
+import { PrinterOutlined, EditOutlined } from '@ant-design/icons'
+import { Tooltip } from 'antd'
 import s from './style.module.scss'
 
 interface Props {
@@ -38,6 +39,9 @@ const GroupedReceiptForm: FC<Props> = ({
     <>
       <PrinterOutlined className={s.print} onClick={handlePrint} />
 
+      <Tooltip title="Режим редагування">
+        <EditOutlined className={s.edit} />
+      </Tooltip>
       <div
         className={s.invoiceContainer}
         ref={componentRef}

--- a/common/components/Forms/GroupedReceiptForm/index.tsx
+++ b/common/components/Forms/GroupedReceiptForm/index.tsx
@@ -1,6 +1,8 @@
 import { IExtendedPayment } from '@common/api/paymentApi/payment.api.types'
 import GroupedPricesTable from '@components/Forms/GroupedReceiptForm/GroupedPricesTable'
+import { usePaymentContext } from '@components/AddPaymentModal'
 import numberToTextNumber from '@utils/numberToText'
+import { getCurrencyShortLabel, normalizeCurrency } from '@utils/helpers'
 import dayjs from 'dayjs'
 import { FC, useRef } from 'react'
 import { useReactToPrint } from 'react-to-print'
@@ -19,8 +21,13 @@ const GroupedReceiptForm: FC<Props> = ({
   paymentData,
   paymentActions,
 }) => {
+  const { company } = usePaymentContext()
   const rawData = currPayment ?? paymentData ?? null
   const data = rawData as any
+  const currency =
+    data?.company?.currency || company?.currency || data?.domain?.currency
+  const currencyLabel = getCurrencyShortLabel(currency)
+  const isEnglish = normalizeCurrency(currency) !== 'UAH'
 
   const componentRef = useRef<HTMLDivElement | null>(null)
 
@@ -55,7 +62,7 @@ const GroupedReceiptForm: FC<Props> = ({
       >
         <>
           <div className={s.providerInfo}>
-            <div className={s.label}>Постачальник</div>
+            <div className={s.label}>{isEnglish ? 'Provider' : 'Постачальник'}</div>
             <pre className={s.preLabel}>
               {data?.provider?.description?.trim()} <br />
               <br />
@@ -63,7 +70,7 @@ const GroupedReceiptForm: FC<Props> = ({
           </div>
 
           <div className={s.receiverInfo}>
-            <div className={s.label}>Одержувач</div>
+            <div className={s.label}>{isEnglish ? 'Recipient' : 'Одержувач'}</div>
             <pre className={s.preLabel}>
               {data?.reciever?.description?.trim()} <br />
               {data?.reciever?.companyName} <br />
@@ -77,16 +84,22 @@ const GroupedReceiptForm: FC<Props> = ({
         </>
 
         <div className={s.providerInvoice}>
-          <div className={s.datecellTitle}>РАХУНОК № {data.invoiceNumber}</div>
+          <div className={s.datecellTitle}>
+            {isEnglish ? 'INVOICE №' : 'РАХУНОК №'} {data.invoiceNumber}
+          </div>
           <div className={s.datecellDate}>
-            Від &nbsp;
+            {isEnglish ? 'dated' : 'Від'} &nbsp;
             {dayjs(data?.invoiceCreationDate)?.format?.('DD.MM.YYYY')}
-            &nbsp; року.
+            {isEnglish ? '.' : ' року.'}
           </div>
           <div className={s.datecell}>
-            Підлягає сплаті до &nbsp;
+            {isEnglish ? 'Due by' : 'Підлягає сплаті до'} &nbsp;
             {dayjs(data?.invoiceCreationDate).add(5, 'd').format('DD.MM.YYYY')}
-            &nbsp; року
+            {!isEnglish && (
+              <>
+                &nbsp; року
+              </>
+            )}
           </div>
         </div>
 
@@ -94,23 +107,30 @@ const GroupedReceiptForm: FC<Props> = ({
           <GroupedPricesTable
             preview
             domainId={data?.domain?._id ?? data?.domain}
+            currency={currency}
             invoices={data?.invoice ?? []}
           />
         </div>
 
         <div className={s.payTable}>
           <div className={s.payFixed}>
-            Загальна сума оплати:
+            {isEnglish ? 'Total payment amount:' : 'Загальна сума оплати:'}
             <div className={s.payBoldSum}>
-              {(+data?.generalSum || +data?.debit || 0).toFixed(2)} грн
+              {(+data?.generalSum || +data?.debit || 0).toFixed(2)}{' '}
+              {currencyLabel}
             </div>
           </div>
 
           <div>
-            Призначення платежу:{' '}
+            {isEnglish ? 'Payment purpose:' : 'Призначення платежу:'}{' '}
             <strong>
-              Оплата за послуги згідно рахунку № {data.invoiceNumber} від{' '}
-              {dayjs(data?.invoiceCreationDate)?.format?.('DD.MM.YYYY')}
+              {isEnglish
+                ? `Payment for services according to invoice № ${data.invoiceNumber} dated ${dayjs(
+                    data?.invoiceCreationDate
+                  )?.format?.('DD.MM.YYYY')}`
+                : `Оплата за послуги згідно рахунку № ${data.invoiceNumber} від ${dayjs(
+                    data?.invoiceCreationDate
+                  )?.format?.('DD.MM.YYYY')}`}
             </strong>
           </div>
 
@@ -125,14 +145,31 @@ const GroupedReceiptForm: FC<Props> = ({
 }
 
 function SumWithText({ data }: { data?: any }) {
+  const { company } = usePaymentContext()
+  const currency =
+    data?.company?.currency || company?.currency || data?.domain?.currency
+  const currencyLabel = getCurrencyShortLabel(currency)
+  const isEnglish = normalizeCurrency(currency) !== 'UAH'
   const rest = numberToTextNumber(data?.generalSum || data?.debit)
+
+  if (isEnglish) {
+    return (
+      <div className={s.payFixed}>
+        Total amount:
+        <div className={s.payBold}>
+          {(+data?.generalSum || +data?.debit || 0).toFixed(2)} {currencyLabel}
+        </div>
+      </div>
+    )
+  }
+
   return (
     rest && (
       <div className={s.payFixed}>
         Всього на суму:
         <div className={s.payBold}>
           {rest}
-          &nbsp;грн
+          &nbsp;{currencyLabel}
         </div>
       </div>
     )

--- a/common/components/Forms/GroupedReceiptForm/style.module.scss
+++ b/common/components/Forms/GroupedReceiptForm/style.module.scss
@@ -1,7 +1,16 @@
 .print {
   position: absolute;
   top: -80px;
-  right: 48px;
+  right: 80px;
+  user-select: none;
+  cursor: pointer;
+  font-size: 25px;
+}
+
+.edit {
+  position: absolute;
+  top: -80px;
+  right: 40px;
   user-select: none;
   cursor: pointer;
   font-size: 25px;

--- a/common/components/Forms/PaymentReceiptForm/index.tsx
+++ b/common/components/Forms/PaymentReceiptForm/index.tsx
@@ -1,5 +1,6 @@
 import { IExtendedPayment } from '@common/api/paymentApi/payment.api.types'
 import numberToTextNumber from '@utils/numberToText'
+import { getCurrencyShortLabel } from '@utils/helpers'
 import dayjs from 'dayjs'
 import { FC, useRef } from 'react'
 import { useReactToPrint } from 'react-to-print'
@@ -15,6 +16,8 @@ interface Props {
 
 const PaymentReceiptForm: FC<Props> = ({ currPayment, paymentData }) => {
   const newData = currPayment || paymentData
+  const currency = newData?.company?.currency || newData?.domain?.currency
+  const currencyLabel = getCurrencyShortLabel(currency)
   const componentRef = useRef()
   const { token } = theme.useToken()
 
@@ -81,7 +84,8 @@ const PaymentReceiptForm: FC<Props> = ({ currPayment, paymentData }) => {
               </div>
               <div className={s.payFixed}>
                 <strong>Отримана сума:</strong>
-                {(+newData?.generalSum || +newData?.debit).toFixed(2)} грн
+                {(+newData?.generalSum || +newData?.debit).toFixed(2)}{' '}
+                {currencyLabel}
               </div>
             </div>
           </div>

--- a/common/components/Forms/ReceiptForm/index.tsx
+++ b/common/components/Forms/ReceiptForm/index.tsx
@@ -1,6 +1,8 @@
 import { IExtendedPayment } from '@common/api/paymentApi/payment.api.types'
 import PaymentPricesTable from '@components/Forms/AddPaymentForm/PaymentPricesTable'
+import { usePaymentContext } from '@components/AddPaymentModal'
 import numberToTextNumber from '@utils/numberToText'
+import { getCurrencyShortLabel, normalizeCurrency } from '@utils/helpers'
 import dayjs from 'dayjs'
 import { FC, useRef } from 'react'
 import { useReactToPrint } from 'react-to-print'
@@ -18,7 +20,12 @@ const ReceiptForm: FC<Props> = ({
   paymentData,
   paymentActions,
 }) => {
+  const { company } = usePaymentContext()
   const newData = currPayment || paymentData
+  const currency =
+    newData?.company?.currency || company?.currency || newData?.domain?.currency
+  const currencyLabel = getCurrencyShortLabel(currency)
+  const isEnglish = normalizeCurrency(currency) !== 'UAH'
   const componentRef = useRef()
   const handlePrint = useReactToPrint({
     content: () => componentRef.current,
@@ -44,7 +51,7 @@ const ReceiptForm: FC<Props> = ({
       >
         <div className={s.providerInvoice}>
           <div className={s.datecellTitle}>
-            ДОВІДКА № {newData.invoiceNumber}
+            {isEnglish ? 'CERTIFICATE №' : 'ДОВІДКА №'} {newData.invoiceNumber}
           </div>
         </div>
         <div className={s.tableSum}>
@@ -53,9 +60,10 @@ const ReceiptForm: FC<Props> = ({
         <div className={s.payTable}>
           <SumWithText data={newData} />
           <div className={s.payFixed}>
-            Загальна сума:
+            {isEnglish ? 'Total amount:' : 'Загальна сума:'}
             <div className={s.payBoldSum}>
-              {(+newData?.generalSum || +newData?.debit).toFixed(2)} грн
+              {(+newData?.generalSum || +newData?.debit).toFixed(2)}{' '}
+              {currencyLabel}
             </div>
           </div>
         </div>
@@ -65,14 +73,31 @@ const ReceiptForm: FC<Props> = ({
 }
 
 function SumWithText({ data }) {
+  const { company } = usePaymentContext()
+  const currency =
+    data?.company?.currency || company?.currency || data?.domain?.currency
+  const currencyLabel = getCurrencyShortLabel(currency)
+  const isEnglish = normalizeCurrency(currency) !== 'UAH'
   const rest = numberToTextNumber(data?.generalSum || data?.debit)
+
+  if (isEnglish) {
+    return (
+      <div className={s.payFixed}>
+        Total in words:
+        <div className={s.payBold}>
+          {(+data?.generalSum || +data?.debit || 0).toFixed(2)} {currencyLabel}
+        </div>
+      </div>
+    )
+  }
+
   return (
     rest && (
       <div className={s.payFixed}>
         Всього на суму:
         <div className={s.payBold}>
           {rest}
-          &nbsp;грн
+          &nbsp;{currencyLabel}
         </div>
       </div>
     )

--- a/common/components/Tables/Companies/CompanisTable.test.tsx
+++ b/common/components/Tables/Companies/CompanisTable.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CompaniesTable from './Table';
+import { realEstates, domains, streets, users } from '@utils/testData';
+import { IGetRealestateResponse } from '@common/api/realestateApi/realestate.api.types';
+
+
+jest.mock('@common/api/userApi/user.api', () => ({
+  useGetCurrentUserQuery: jest.fn(),
+}));
+
+jest.mock('@common/api/realestateApi/realestate.api', () => ({
+  useDeleteRealEstateMutation: jest.fn(),
+  useUpdateArchivedItemMutation: jest.fn(),
+}));
+
+jest.mock('@common/api/filterApi/filter.api', () => ({
+  useGetAddressFiltersQuery: jest.fn(),
+  useGetDomainFiltersQuery: jest.fn(),
+  useGetRealEstateFiltersQuery: jest.fn(),
+}));
+
+jest.mock('@common/api/debtorsApi/debtors.api', () => ({
+  useGetDebtorsQuery: jest.fn(),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+const mockProps = {
+  realEstates: {
+    data: [],
+    success: true,
+    domainsFilter: [],
+    realEstatesFilter: [],
+    streetsFilter: [],
+  } as IGetRealestateResponse,
+  isLoading: false,
+  isError: false,
+  filters: {},
+  setFilters: jest.fn(),
+  setRealEstateActions: jest.fn(),
+  realEstateActions: { edit: false },
+  isArchive: false,
+  customServices: [],
+};
+
+describe('CompaniesTable - Column Visibility', () => {
+  beforeEach(() => {
+    const { useGetCurrentUserQuery } = require('@common/api/userApi/user.api');
+    useGetCurrentUserQuery.mockReturnValue({
+      data: users.globalAdmin,
+    });
+
+    const { useDeleteRealEstateMutation, useUpdateArchivedItemMutation } = require('@common/api/realestateApi/realestate.api');
+    useDeleteRealEstateMutation.mockReturnValue([jest.fn(), { isLoading: false }]);
+    useUpdateArchivedItemMutation.mockReturnValue([jest.fn(), { isLoading: false }]);
+
+    const { useGetAddressFiltersQuery, useGetDomainFiltersQuery, useGetRealEstateFiltersQuery } = require('@common/api/filterApi/filter.api');
+    useGetAddressFiltersQuery.mockReturnValue({ data: { streetsFilter: [] } });
+    useGetDomainFiltersQuery.mockReturnValue({ data: { domainsFilter: [] } });
+    useGetRealEstateFiltersQuery.mockReturnValue({ data: { realEstatesFilter: [] } });
+
+    const { useGetDebtorsQuery } = require('@common/api/debtorsApi/debtors.api');
+    useGetDebtorsQuery.mockReturnValue({ data: { companies: [] } });
+
+
+    const { useRouter } = require('next/router');
+    useRouter.mockReturnValue({
+      pathname: '/real-estate',
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+
+  test('should display company column when there are multiple unique companies', () => {
+    const mockRealEstates: IGetRealestateResponse = {
+      data: [
+        { ...realEstates[0], 
+            domain: { ...domains[0], mfo: '', iban: '', rnokpp: '', IEName: '' } as any, 
+            street: { ...streets[0], _v: 1 } as any, companyName: 'Company A', _v: 1, services: [] },
+        { ...realEstates[1], 
+            domain: { ...domains[1], mfo: '', iban: '', rnokpp: '', IEName: '' } as any, 
+            street: { ...streets[1], _v: 1 } as any, companyName: 'Company B', _v: 1, services: [] },
+      ],
+      success: true,
+      domainsFilter: [],
+      realEstatesFilter: [],
+      streetsFilter: [],
+    };
+
+    render(<CompaniesTable {...mockProps} realEstates={mockRealEstates} />);
+
+    expect(screen.getByText('Назва компанії')).toBeInTheDocument();
+  });
+
+  test('should hide company column when there is only one unique company', () => {
+    const mockRealEstates: IGetRealestateResponse = {
+      data: [
+        { ...realEstates[0], 
+            domain: { ...domains[0], mfo: '', iban: '', rnokpp: '', IEName: '' } as any, 
+            street: { ...streets[0], _v: 1 } as any, companyName: 'Company A', _v: 1, services: [] },
+        { ...realEstates[1], 
+            domain: { ...domains[1], mfo: '', iban: '', rnokpp: '', IEName: '' } as any, 
+            street: { ...streets[1], _v: 1 } as any, companyName: 'Company A', _v: 1, services: [] },
+      ],
+      success: true,
+      domainsFilter: [],
+      realEstatesFilter: [],
+      streetsFilter: [],
+    };
+
+    render(<CompaniesTable {...mockProps} realEstates={mockRealEstates} />);
+
+    expect(screen.queryByText('Назва компанії')).not.toBeInTheDocument();
+  });
+
+  test('should display company column when data is empty', () => {
+
+    const mockRealEstates: IGetRealestateResponse = {
+      data: [],
+      success: true,
+      domainsFilter: [],
+      realEstatesFilter: [],
+      streetsFilter: [],
+    };
+
+    render(<CompaniesTable {...mockProps} realEstates={mockRealEstates} />);
+
+    expect(screen.getByText('Назва компанії')).toBeInTheDocument();
+  });
+});
+

--- a/common/components/Tables/Companies/Header.tsx
+++ b/common/components/Tables/Companies/Header.tsx
@@ -1,5 +1,5 @@
 import { PlusOutlined, SelectOutlined } from '@ant-design/icons'
-import { Button, Space, Segmented } from 'antd'
+import { Button, Space, Segmented, Select } from 'antd'
 import { useRouter } from 'next/router'
 import { Dispatch, SetStateAction, useState } from 'react'
 import {
@@ -19,6 +19,7 @@ import {
   useGetDomainFiltersQuery,
   useGetRealEstateFiltersQuery,
 } from '@common/api/filterApi/filter.api'
+import { useGetCustomServicesQuery } from '@common/api/customServicesApi/customServices.api'
 
 export interface Props {
   showAddButton?: boolean
@@ -55,6 +56,9 @@ const CompaniesHeader: React.FC<Props> = ({
   const router = useRouter()
   const [isModalOpen, setIsModalOpen] = useState(false)
 
+  const { data: customServicesResponse } = useGetCustomServicesQuery({})
+  const customServices = customServicesResponse?.data || []
+  
   const { data: user } = useGetCurrentUserQuery()
   const isAdmin = isAdminCheck(user?.roles)
 
@@ -80,6 +84,13 @@ const CompaniesHeader: React.FC<Props> = ({
     streets: filters?.street,
     realEstates: filters?.company,
   })
+
+  const handleServicesChange = (values: string[]) => {
+  setFilters((prev: any) => ({
+    ...prev,
+    services: values,
+  }))
+}
 
   return (
     <div className={s.headerBlock}>
@@ -111,8 +122,28 @@ const CompaniesHeader: React.FC<Props> = ({
             />
           </Space>
         )}
+      <div style={{ position: 'absolute', left: 400,}}>
+      <Select
+        mode="multiple"
+        allowClear
+        placeholder="Фільтр послуг"
+        style={{ width: "250px" }}
+        value={filters?.services || []}
+        onChange={handleServicesChange}
+        maxTagCount="responsive"
+      >
+        {customServices.length > 0 && (
+        <Select.OptGroup label="Кастомні">
+          {customServices.map((service) => (
+            <Select.Option key={service._id} value={service._id}>
+              {service.name}
+            </Select.Option>
+        ))}
+        </Select.OptGroup>
+      )}
+    </Select>
+    </div>  
       </div>
-
       <div className={s.segmented}>
         <Segmented
           options={[

--- a/common/components/Tables/Companies/Table.tsx
+++ b/common/components/Tables/Companies/Table.tsx
@@ -31,6 +31,7 @@ import {
   Dropdown,
   Switch,
   Badge,
+  Select,
 } from 'antd'
 import { ColumnType } from 'antd/lib/table'
 import { useRouter } from 'next/router'
@@ -57,18 +58,17 @@ type CompanyWithPayments = {
   totalDebt: number
 }
 
-const STANDARD_SERVICE_NAMES = [
-  'Опис',
-  'Площа (м²)',
-  'Ціна (грн/м²)',
-  'Індивідуальне утримання (грн/м²)',
-  'Частка загальної площі',
-  'Частка водопостачання',
-  'Прибирання (грн)',
-  'Знижка',
-  'Вивіз сміття',
-  'Нарахування інд. інф.',
-]
+const SERVICE_COLUMNS_CONFIG: Record<string, any> = {
+  totalArea: { title: 'Площа (м²)', width: 120 },
+  pricePerMeter: { title: 'Ціна (грн/м²)', width: 120, isPrice: true },
+  servicePricePerMeter: { title: 'Індивідуальне утримання (грн/м²)', width: 200, isPrice: true },
+  rentPart: { title: 'Частка загальної площі', width: 200 },
+  waterPart: { title: 'Частка водопостачання', width: 180 },
+  cleaning: { title: 'Прибирання (грн)', width: 150, isPrice: true },
+  discount: { title: 'Знижка', width: 150, isPrice: true },
+  garbageCollector: { title: 'Вивіз сміття', width: 150, isCheckbox: true },
+  inflicion: { title: 'Нарахування інд. інф.', width: 170, isCheckbox: true },
+};
 
 export interface Props {
   domainId?: string
@@ -103,7 +103,7 @@ const CompaniesTable: React.FC<Props> = ({
   setRealEstateActions,
   realEstateActions,
   isArchive,
-  customServices,
+  customServices,  
 }) => {
   const router = useRouter()
   const { pathname } = router
@@ -174,6 +174,17 @@ const CompaniesTable: React.FC<Props> = ({
       message.error('Виникла помилка')
     }
   }
+  const dataSource = useMemo(() => {
+  const rawData = realEstates?.data || []
+  if (rawData.length === 0) return []
+
+  const data = [...rawData]
+
+  data.sort((a, b) => (a.companyName || '').localeCompare(b.companyName || ''))
+
+  return data
+}, [realEstates?.data])
+
 
   const isGlobalAdmin = userResponse?.roles?.includes(Roles.GLOBAL_ADMIN)
   const isUser = userResponse?.roles?.includes(Roles.USER)
@@ -194,7 +205,7 @@ const CompaniesTable: React.FC<Props> = ({
 
   const filteredCustomServices = useMemo(() => {
     return customServices?.filter((custom) => {
-      const isStandardName = STANDARD_SERVICE_NAMES.includes(custom.name)
+      const isStandardName = Object.keys(SERVICE_COLUMNS_CONFIG).includes(custom.name)
       return !isStandardName
     })
   }, [customServices])
@@ -257,9 +268,9 @@ const CompaniesTable: React.FC<Props> = ({
         debtorCompanies,
         isUser,
         isSingleCompanyByData,
-        customServices: filteredCustomServices,
+        customServices: filteredCustomServices, 
       })}
-      dataSource={realEstates?.data}
+      dataSource={dataSource}
       scroll={{ x: tableWidth }}
       onChange={(__, filters) => {
         const newFilters: any = {
@@ -324,25 +335,72 @@ const getDefaultColumns = ({
   streetsFilter: IFilter[]
   filters?: any
   pathname?: string
-  setRealEstateActions: React.Dispatch<
-    React.SetStateAction<{
-      edit: boolean
-    }>
-  >
+  setRealEstateActions: React.Dispatch<React.SetStateAction<{ edit: boolean }>>
   debtorCompanies?: CompanyWithPayments[]
   isUser?: boolean
   isSingleCompanyByData?: boolean
-  customServices?: { _id: string; name: string }[]
+  customServices?: { _id: string; name: string; fieldName?: string }[]
 }): ColumnType<any>[] => {
   const isOnPage = pathname === AppRoutes.REAL_ESTATE
-  const columns: ColumnType<any>[] = [
+  const selectedServices = filters?.services || []
+
+  const showAll = selectedServices.length === 0
+  const keysToRender = showAll 
+  ? [
+      ...Object.keys(SERVICE_COLUMNS_CONFIG), 
+      ...(customServices?.map(s => s._id) || [])
+    ] : selectedServices
+
+  const dynamicServiceColumns = keysToRender.map((key) => {
+    const config = SERVICE_COLUMNS_CONFIG[key]
+
+    if (config) {
+      return {
+        title: config.title,
+        dataIndex: key,
+        key,
+        width: config.width,
+        align: 'center',
+        sorter: !config.isCheckbox && isOnPage ? (a, b) => a[key] - b[key] : null,
+        render: (value) => {
+          if (config.isCheckbox) return <Checkbox checked={value} disabled />
+          if (config.isPrice) return value ? renderCurrency(value) : <span className={s.currency}>-</span>
+          return value || '-'
+        },
+      }
+    }
+
+    const customSrv = customServices?.find((s) => s._id === key || s.fieldName === key)
+    if (customSrv) {
+      return {
+        title: customSrv.name,
+        key,
+        width: 160,
+        align: 'center',
+        render: (_, record: IExtendedRealestate) => {
+          const allServices = [
+            ...(record.services || []),
+            ...(record.customServices || []),
+            ...((record as any).individualServices || [])
+          ]
+          
+          const match = allServices.find(
+            (s) => String(s._id || s.serviceId) === String(customSrv._id)
+          )
+          
+          return match?.price ? renderCurrency(match.price) : <span className={s.currency}>-</span>
+        },
+      }
+    }
+    return null
+  }).filter(Boolean) as ColumnType<any>[]
+
+  const resultColumns: ColumnType<any>[] = [
     {
       title: 'Адміністратори',
       dataIndex: 'adminEmails',
       width: 250,
-      render: (adminEmails) => (
-        <CollapsedTags items={adminEmails} maxVisible={2} />
-      ),
+      render: (adminEmails) => <CollapsedTags items={adminEmails} maxVisible={2} />,
     },
     {
       title: 'Опис',
@@ -351,170 +409,30 @@ const getDefaultColumns = ({
       align: 'center',
       render: renderTooltip,
     },
-    // TODO: enum
-    {
-      title: 'Площа (м²)',
-      dataIndex: 'totalArea',
-      width: 120,
-      align: 'center',
-      sorter: isOnPage ? (a, b) => a.totalArea - b.totalArea : null,
-    },
-    {
-      title: 'Ціна (грн/м²)',
-      dataIndex: 'pricePerMeter',
-      width: 120,
-      align: 'center',
-      sorter: isOnPage ? (a, b) => a.pricePerMeter - b.pricePerMeter : null,
-      render: (value) => <span className={s.currency}>{renderPrice(value)}</span>
-
-    },
-    {
-      title: 'Індивідуальне утримання (грн/м²)',
-      dataIndex: 'servicePricePerMeter',
-      width: 200,
-      align: 'center',
-      sorter: isOnPage
-        ? (a, b) => a.servicePricePerMeter - b.servicePricePerMeter
-        : null,
-      render: (value) =>
-        value !== null && value !== undefined && value !== 0 ? (
-          renderCurrency(value)
-        ) : (
-          <span className={s.currency}>-</span>
-        ),
-    },
-    {
-      title: 'Частка загальної площі',
-      dataIndex: 'rentPart',
-      width: 180,
-      align: 'center',
-      sorter: isOnPage ? (a, b) => a.rentPart - b.rentPart : null,
-    },
-    {
-      title: 'Частка водопостачання',
-      dataIndex: 'waterPart',
-      width: 180,
-      align: 'center',
-      sorter: isOnPage ? (a, b) => a.waterPart - b.waterPart : null,
-    },
-    {
-      title: 'Прибирання (грн)',
-      dataIndex: 'cleaning',
-      width: 150,
-      align: 'center',
-      sorter: isOnPage ? (a, b) => a.cleaning - b.cleaning : null,
-      render: (value) =>
-        value !== null && value !== undefined && value !== 0 ? (
-          renderCurrency(value)
-        ) : (
-          <span className={s.currency}>-</span>
-        ),
-    },
-    {
-      title: 'Знижка',
-      dataIndex: 'discount',
-      width: 150,
-      align: 'center',
-      sorter: isOnPage ? (a, b) => a.discount - b.discount : null,
-      render: (value) =>
-        value !== null && value !== undefined && value !== 0 ? (
-          renderCurrency(value)
-        ) : (
-          <span className={s.currency}>-</span>
-        ),
-    },
-    {
-      align: 'center',
-      title: 'Вивіз сміття',
-      dataIndex: 'garbageCollector',
-      width: 150,
-      render: (value) => <Checkbox checked={value} disabled />,
-    },
-    {
-      align: 'center',
-      title: 'Нарахування інд. інф.',
-      dataIndex: 'inflicion',
-      width: 170,
-      render: (value) => <Checkbox checked={value} disabled />,
-    },
+    ...dynamicServiceColumns
   ]
-
-  if (customServices?.length) {
-    customServices.forEach((custom) => {
-      columns.push({
-        title: custom.name,
-        dataIndex: custom._id,
-        width: 150,
-        align: 'center',
-        ellipsis: true,
-        render: (_, record: IExtendedRealestate) => {
-          const match = (record as any).individualServices?.find(
-            (s) => String(s._id) === String(custom._id)
-          )
-          return match ? (
-            renderCurrency(match.price)
-          ) : (
-            <span className={s.currency}>-</span>
-          )
-        },
-      })
-    })
-  }
-
+  
   if (isAdmin) {
-    columns.push({
-      fixed: 'right',
-      align: 'center',
-      title: '',
-      width: 56,
+    resultColumns.push({
+      fixed: 'right', align: 'center', title: '', width: 56,
       render: (_, realEstate: IExtendedRealestate) => (
-        <Button
-          icon={<EditOutlined />}
-          type="link"
-          onClick={() => {
+        <Button icon={<EditOutlined />} type="link" onClick={() => {
             setCurrentRealEstate(realEstate)
             setRealEstateActions({ edit: true })
-          }}
-        />
+        }} />
       ),
     })
-  }
-  if (isAdmin) {
-    columns.push({
-      align: 'center',
-      fixed: 'right',
-      title: '',
-      width: 98,
+
+    resultColumns.push({
+      align: 'center', fixed: 'right', title: '', width: 98,
       render: (_, realEstate: IExtendedRealestate) => (
-        <Dropdown
-          menu={{
+        <Dropdown menu={{
             items: [
               {
                 key: 'archive',
                 label: (
-                  <Popconfirm
-                    id="popconfirm_archive"
-                    title={`Ви впевнені що хочете ${
-                      realEstate.archived ? 'розархівувати' : 'архівувати'
-                    } цей елемент?`}
-                    onConfirm={() =>
-                      handleArchive(realEstate?._id, !realEstate.archived)
-                    }
-                    okText={
-                      realEstate.archived ? 'Розархівувати' : 'Архівувати'
-                    }
-                    cancelText="Ні"
-                    disabled={archiveLoading}
-                  >
-                    <Button
-                      type="text"
-                      icon={<InboxOutlined />}
-                      style={{
-                        color: realEstate.archived ? '#722ed1' : '#ff4d4f',
-                        paddingLeft: '10px',
-                        paddingRight: '10px',
-                      }}
-                    >
+                  <Popconfirm title={`Ви впевнені?`} onConfirm={() => handleArchive(realEstate?._id, !realEstate.archived)}>
+                    <Button type="text" icon={<InboxOutlined />} style={{ color: realEstate.archived ? '#722ed1' : '#ff4d4f', padding: '0 10px' }}>
                       {realEstate.archived ? 'Розархівувати' : 'Архівувати'}
                     </Button>
                   </Popconfirm>
@@ -523,29 +441,12 @@ const getDefaultColumns = ({
               isGlobalAdmin && {
                 key: 'delete',
                 label: (
-                  <Popconfirm
-                    id="popconfirm_custom"
-                    title={`Ви впевнені що хочете видалити нерухомість?`}
-                    onConfirm={() => handleDelete(realEstate?._id)}
-                    okText="Видалити"
-                    cancelText="Ні"
-                    disabled={deleteLoading}
-                  >
-                    <Button
-                      type="text"
-                      icon={<DeleteOutlined />}
-                      style={{
-                        color: '#ff4d4f',
-                        paddingLeft: '10px',
-                        paddingRight: '10px',
-                      }}
-                    >
-                      Видалити
-                    </Button>
+                  <Popconfirm title="Видалити нерухомість?" onConfirm={() => handleDelete(realEstate?._id)}>
+                    <Button type="text" icon={<DeleteOutlined />} style={{ color: '#ff4d4f', padding: '0 10px' }}>Видалити</Button>
                   </Popconfirm>
                 ),
               },
-            ],
+            ].filter(Boolean) as any,
           }}
           placement="bottomRight"
         >
@@ -555,92 +456,46 @@ const getDefaultColumns = ({
     })
   }
 
+  const streetColumn: any = {
+    title: 'Адреса', dataIndex: 'street', width: 260,
+    render: (i: any) => i ? `${i.address} (м. ${i.city})` : '-',
+  }
+
   const domainColumn: any = {
-    title: 'Надавач послуг',
-    dataIndex: 'domain',
-    width: 200,
-    render: (i) => i?.name,
+    title: 'Надавач послуг', dataIndex: 'domain', width: 200,
+    render: (i: any) => i?.name,
     hidden: domainsFilter?.length <= 1,
-    filterSearch: true,
   }
 
   const companyColumn: any = {
-    fixed: 'left',
-    title: 'Назва компанії',
-    dataIndex: 'companyName',
-    width: 200,
-    filterSearch: true,
-    render: (i: string) => {
-      if (isUser || !debtorCompanies) return i;
-      const debtor = debtorCompanies?.find(
-        (companie) => companie?.companyName === i
-      );
-
-       if (!debtor) return i;
-
-      const tooltipDebtor = (
-        <div>
-          <p><b>Компанія боржник</b></p>
-          <p>Назва компанії: {i}</p>
-          <p>Сума боргу: {formatDebt(debtor.totalDebt)}</p>
-        </div>
-      );
-
+    fixed: 'left', title: 'Назва компанії', dataIndex: 'companyName', width: 200,
+    render: (name: string) => {
+      const debtor = debtorCompanies?.find((c) => c.companyName === name)
+      if (isUser || !debtor) return name
       return (
-        <Badge
-          count={formatDebt(debtor.totalDebt)}
-          title=""
-          color={getDebtorTooltipColor(debtor)}
-          overflowCount={Infinity}
-          style={{ cursor: 'pointer' }}
-          size="small"
-          offset={[3, -8]}
-        >
-          <Tooltip title={tooltipDebtor}>
-            <span style={{cursor: 'pointer'}}>{i}</span>
-          </Tooltip>
+        <Badge count={formatDebt(debtor.totalDebt)} color={getDebtorTooltipColor(debtor)} size="small" offset={[3, -8]}>
+          <Tooltip title="Компанія боржник"><span style={{ cursor: 'pointer', fontWeight: 500 }}>{name}</span></Tooltip>
         </Badge>
-      );
+      )
     },
-  };
-
-  const streetColumn: any = {
-    title: 'Адреса',
-    dataIndex: 'street',
-    width: 200,
-    filterSearch: true,
-    render: (i) => (
-      <>
-        {i?.address} (м. {i?.city})
-      </>
-    ),
   }
 
   if (isAdmin) {
     if (!isSingleCompanyByData) {
-      companyColumn.filters =
-        pathname === AppRoutes.REAL_ESTATE ? realEstatesFilter : null
+      companyColumn.filters = isOnPage ? realEstatesFilter : null
       companyColumn.filteredValue = filters?.company || null
     }
-
-    domainColumn.filters =
-      pathname === AppRoutes.REAL_ESTATE ? domainsFilter : null
+    domainColumn.filters = isOnPage ? domainsFilter : null
     domainColumn.filteredValue = filters?.domain || null
-
-    streetColumn.filters =
-      pathname === AppRoutes.REAL_ESTATE ? streetsFilter : null
+    streetColumn.filters = isOnPage ? streetsFilter : null
     streetColumn.filteredValue = filters?.street || null
   }
 
-  columns.unshift(streetColumn)
+  resultColumns.unshift(streetColumn)
+  resultColumns.unshift(domainColumn)
+  if (!isSingleCompanyByData) resultColumns.unshift(companyColumn)
 
-  columns.unshift(domainColumn)
-
-  if (!isSingleCompanyByData) {
-    columns.unshift(companyColumn)
-  }
-
-  return columns
+  return resultColumns
 }
 
 export default CompaniesTable

--- a/common/components/Tables/Domains/DomainsTable.test.tsx
+++ b/common/components/Tables/Domains/DomainsTable.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import  DomainsTable  from './Table'
+import '@testing-library/jest-dom'
+
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    pathname: '/domains',
+  }),
+}))
+
+jest.mock('@common/api/domainApi/domain.api', () => ({
+  useGetDomainsQuery: jest.fn(),
+  useDeleteDomainMutation: jest.fn(),
+}))
+
+import {
+  useGetDomainsQuery,
+  useDeleteDomainMutation,
+} from '@common/api/domainApi/domain.api'
+
+
+const mockDomains = [
+  {
+    _id: '1',
+    name: 'Van PRO Ltd.',
+    adminEmails: ['admin@test.com'],
+    description: 'Test domain',
+  },
+  {
+    _id: '2',
+    name: 'Rozetka',
+    adminEmails: ['admin@rozetka.ua'],
+    description: 'Second domain',
+  },
+]
+
+const renderComponent = (props = {}) =>
+  render(
+    <DomainsTable
+        domainId={null}
+        setCurrentDomain={jest.fn()}
+        setDomainActions={jest.fn()}
+        setDomainsLength={jest.fn()}
+        domainActions={{ edit: false }}
+      {...props}
+    />
+  )
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  
+  ;(useDeleteDomainMutation as jest.Mock).mockReturnValue([
+    jest.fn(),
+    { isLoading: false },
+  ])
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+it('renders domains table with data', () => {
+  ;(useGetDomainsQuery as jest.Mock).mockReturnValue({
+    data: mockDomains,
+    isLoading: false,
+    isError: false,
+    refetch: jest.fn(),
+  })
+
+  renderComponent()
+
+  expect(screen.getByText('Van PRO Ltd.')).toBeInTheDocument()
+  expect(screen.getByText('Rozetka')).toBeInTheDocument()
+})
+
+it('calls setDomainsLength after data load', () => {
+  const setDomainsLength = jest.fn()
+
+  ;(useGetDomainsQuery as jest.Mock).mockReturnValue({
+    data: mockDomains,
+    isLoading: false,
+    isError: false,
+  })
+
+  renderComponent({ setDomainsLength })
+
+  expect(setDomainsLength).toHaveBeenCalledWith(2)
+})
+
+it('shows error alert when request fails', () => {
+  ;(useGetDomainsQuery as jest.Mock).mockReturnValue({
+    data: null,
+    isLoading: false,
+    isError: true,
+  })
+
+  renderComponent()
+
+  expect(screen.getByText('Помилка')).toBeInTheDocument()
+})
+
+
+it('hides "Надавачі послуг" column when only one company in filter', () => {
+  const singleCompany = [
+    {
+      _id: '1',
+      name: 'Van PRO Ltd.',
+      adminEmails: ['admin@test.com'],
+      description: 'Test domain',
+      companies: ['Single Company'],
+    },
+  ]
+
+  ;(useGetDomainsQuery as jest.Mock).mockReturnValue({
+    data: singleCompany,
+    isLoading: false,
+    isError: false,
+  })
+
+  renderComponent()
+
+  expect(screen.queryByText('Надавачі послуг')).not.toBeInTheDocument()
+})
+

--- a/common/components/Tables/EditInvoiceTable/Electricity/index.tsx
+++ b/common/components/Tables/EditInvoiceTable/Electricity/index.tsx
@@ -71,7 +71,7 @@ export const Amount: React.FC<InvoiceComponentProps> = ({
                 {toRoundFixed(lastAmount)} → {toRoundFixed(amount)}
               </div>
               <div>
-                <strong>Втрати:</strong> {losses}%
+                <strong>Втрати:</strong> {(losses).toFixed(2)}%
               </div>
               <div>
                 <strong>З втратами:</strong> {withLosses} кВт

--- a/common/components/Tables/Payment/DateFilter/DateFilterDropdown.tsx
+++ b/common/components/Tables/Payment/DateFilter/DateFilterDropdown.tsx
@@ -12,9 +12,10 @@ const DateFilterDropdown: React.FC<Props> = ({
   confirm,
   clearFilters,
 }) => {
+  const currentYear = new Date().getFullYear()
+  const currentYearData = data.find(d => d.value === String(currentYear))
   const [expandedKeys, setExpandedKeys] = useState<string[]>(() => {
-    const year2025 = data.find(d => d.value === '2025')
-    return year2025 ? [year2025.value] : []
+    return currentYearData ? [currentYearData.value] : []
   })
 
   const treeData = useMemo(
@@ -30,9 +31,8 @@ const DateFilterDropdown: React.FC<Props> = ({
     [data]
   )
   useEffect(() => {
-    const year2025 = data.find(d => d.value === '2025')
-    if (year2025) {
-      setExpandedKeys([year2025.value])
+    if (currentYearData) {
+      setExpandedKeys([currentYearData.value])
     }
   }, [data])
 
@@ -53,8 +53,7 @@ const DateFilterDropdown: React.FC<Props> = ({
         <Button
           onClick={() => {
             clearFilters?.()
-            const year2025 = data.find(d => d.value === '2025')
-            setExpandedKeys(year2025 ? [year2025.value] : [])
+            setExpandedKeys(currentYearData ? [currentYearData.value] : [])
           }}
         >
           Скинути
@@ -63,8 +62,7 @@ const DateFilterDropdown: React.FC<Props> = ({
           type="primary"
           onClick={() => {
             confirm()
-            const year2025 = data.find(d => d.value === '2025')
-            setExpandedKeys(year2025 ? [year2025.value] : [])
+            setExpandedKeys(currentYearData ? [currentYearData.value] : [])
           }}
         >
           OK

--- a/common/components/Tables/Payment/Table.tsx
+++ b/common/components/Tables/Payment/Table.tsx
@@ -223,18 +223,18 @@ const PaymentsTable: React.FC<PaymentsTableProps> = ({
     const list = payments?.data || []
     const uniqueCompanies = new Set(
       list.map((p) =>
-        typeof p.company === 'object' ? p.company.companyName : p.company
+        typeof p.company === 'object' ? p?.company?.companyName : p?.company
       )
     )
-    return filters?.company?.length === 1 && uniqueCompanies.size === 1
+    return filters?.company?.length === 1 && uniqueCompanies?.size === 1
   }, [payments?.data, filters?.company])
-  const isSingleDomainByData = useMemo(() => {
-    const list = payments?.data || []
-    const uniqueDomains = new Set(
-      list.map((p) => (typeof p.domain === 'object' ? p.domain.name : p.domain))
-    )
-    return filters?.domain?.length === 1 && uniqueDomains.size === 1
-  }, [payments?.data, filters?.domain])
+  // const isSingleDomainByData = useMemo(() => {
+  //   const list = payments?.data || []
+  //   const uniqueDomains = new Set(
+  //     list.map((p) => (typeof p?.domain === 'object' ? p.domain?.name : p?.domain))
+  //   )
+  //   return filters?.domain?.length === 1 && uniqueDomains.size === 1
+  // }, [payments?.data, filters?.domain])
 
   const widenFilterDropdown = (w = 240) => (open: boolean) => {
       if (!open) return
@@ -284,9 +284,9 @@ const PaymentsTable: React.FC<PaymentsTableProps> = ({
           ) : (
             <Tooltip title="Додати в фільтри">
               <Typography.Link
-                onClick={() => setFilters({ ...filters, domain: [domain._id] })}
+                onClick={() => setFilters({ ...filters, domain: [domain?._id] })}
               >
-                {domain.name}
+                {domain?.name}
               </Typography.Link>
             </Tooltip>
           ),

--- a/common/components/Tables/PaymentsBulk/column.config.tsx
+++ b/common/components/Tables/PaymentsBulk/column.config.tsx
@@ -310,7 +310,7 @@ const LossElectricitySum: React.FC<{ name: number }> = ({ name }) => {
     ) ?? 0
   return (
     <Space>
-      {service?.losses && (
+      {service?.losses && amount > 0 && (
         <Typography.Text type="secondary" style={{ fontWeight: 'lighter' }}>
           {(
             amount -
@@ -339,7 +339,7 @@ const LossElectricityPrice: React.FC<{ name: number }> = ({ name }) => {
     ) ?? 0
   return (
     <Space>
-      {service?.losses && (
+      {service?.losses && amount > 0 && (
         <Typography.Text type="secondary" style={{ fontWeight: 'lighter' }}>
           {amount - lastAmount} + ({service?.losses}%)
         </Typography.Text>

--- a/common/components/Tables/UsersTable/index.tsx
+++ b/common/components/Tables/UsersTable/index.tsx
@@ -7,6 +7,7 @@ import type { SelectProps } from 'antd'
 import {
   useGetAllUsersQuery,
   useUpdateUserMutation,
+  useGetCurrentUserQuery 
 } from '@common/api/userApi/user.api'
 import type { IUser } from '@common/api/userApi/user.api.types'
 import { Roles } from '@utils/constants'
@@ -63,6 +64,7 @@ const EditUserButton: React.FC<{ userId?: IUser['_id'] }> = ({ userId }) => {
 }
 
 export const UsersTable: React.FC = () => {
+  const { data: currentUser } = useGetCurrentUserQuery()
   const { data: users = [], isLoading } = useGetAllUsersQuery()
   const [updateUser, { isLoading: isUpdatingUser }] =
     useUpdateUserMutation()
@@ -172,6 +174,11 @@ export const UsersTable: React.FC = () => {
         ),
         render: (_, user) => {
           const currentRole = getUserRoleValue(user)
+          const isSelf = currentUser?._id?.toString() === user?._id?.toString()
+          const isGlobalAdminUser = currentRole === Roles.GLOBAL_ADMIN
+          if (isSelf && isGlobalAdminUser) {
+            return 'Global Admin'
+          }
 
           return (
             <Select

--- a/common/components/UI/CustomServicesCard/CustomServicesCard.test.tsx
+++ b/common/components/UI/CustomServicesCard/CustomServicesCard.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { Form } from 'antd'
+import CustomServicesCard from './index'
+import { Roles } from '@utils/constants'
+
+jest.mock('@common/api/userApi/user.api', () => ({
+  useGetCurrentUserQuery: jest.fn(),
+}))
+
+jest.mock('@utils/helpers', () => ({
+  inputNumberParser: jest.fn((v) => v),
+}))
+
+const mockUseGetCurrentUserQuery = require('@common/api/userApi/user.api').useGetCurrentUserQuery as jest.Mock
+const useWatchSpy = jest.spyOn(Form, 'useWatch')
+
+const ALL_CUSTOM_SERVICES = [
+  { _id: '1', label: 'Послуга 1', fieldName: 'service1' },
+]
+
+const renderWithForm = (ui: React.ReactElement) => {
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [form] = Form.useForm()
+    return <Form form={form}>{children}</Form>
+  }
+  return render(ui, { wrapper: Wrapper })
+}
+
+describe('CustomServicesCard', () => {
+  const setFieldsValueMock = jest.fn()
+  const defaultMockUser = { data: { roles: [Roles.DOMAIN_ADMIN] } }
+
+  beforeEach(() => {
+    mockUseGetCurrentUserQuery.mockReturnValue(defaultMockUser)
+    useWatchSpy.mockReturnValue([])
+    setFieldsValueMock.mockClear()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('renders add button when not disabled and not service form', () => {
+    renderWithForm(
+      <CustomServicesCard
+        form={{ setFieldsValue: setFieldsValueMock }}
+        allCustomServices={ALL_CUSTOM_SERVICES}
+        disabled={false}
+        isServiceForm={false}
+      />
+    )
+
+    expect(screen.getByText('Індивідуальні послуги')).toBeInTheDocument()
+  })
+
+  test('adds custom service from dropdown', () => {
+    renderWithForm(
+      <CustomServicesCard
+        form={{ setFieldsValue: setFieldsValueMock }}
+        allCustomServices={ALL_CUSTOM_SERVICES}
+        disabled={false}
+        isServiceForm={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Індивідуальні послуги'))
+    fireEvent.click(screen.getByText('Послуга 1'))
+
+    expect(setFieldsValueMock).toHaveBeenCalledWith({
+      customServices: [
+        {
+          _id: '1',
+          label: 'Послуга 1',
+          fieldName: 'service1',
+          price: 0,
+        },
+      ],
+    })
+  })
+})

--- a/common/components/UI/PaymentCardHeader/PaymentCardLabel.tsx
+++ b/common/components/UI/PaymentCardHeader/PaymentCardLabel.tsx
@@ -69,6 +69,7 @@ const PaymentCardLabel = ({
               className={styles.select}
               setFilters={setFilters}
               streets={streets}
+              filters={filters}
             />
           </div>
           <Space

--- a/common/components/UI/RealEstateComponents/RealEstateModal/RealEstateForm/index.tsx
+++ b/common/components/UI/RealEstateComponents/RealEstateModal/RealEstateForm/index.tsx
@@ -67,9 +67,10 @@ const RealEstateForm: FC<Props> = ({
       form.setFieldsValue({
         ...form.getFieldsValue(),
         services: servicesWithEnabled,
+        discount: currentRealEstate?.discount || 0,
       })
     }
-  }, [services, form])
+  }, [services, currentRealEstate, form])
 
   const isServiceExistById = (serviceId: string) => {
     if (!domain?.customServices?.length) return false
@@ -147,6 +148,22 @@ const RealEstateForm: FC<Props> = ({
         />
       </Form.Item>
       <EmailSelect form={form} disabled={!editable} required={false} />
+          <Form.Item
+            name="discount"
+            label="Знижка"
+            rules={validateField('number')}
+          >
+            <InputNumber
+              min={0}
+              max={100}
+              precision={2} 
+              formatter={(value) => `${value}`}
+              placeholder="Вкажіть знижку"
+              className={s.formInput}
+              disabled={!editable}
+              style={{ width: '100%' }}
+            />
+          </Form.Item>
 
       {isMeterBasedServiceExist && (
         <>

--- a/common/components/UI/RealEstateComponents/RealEstateModal/RealEstateForm/index.tsx
+++ b/common/components/UI/RealEstateComponents/RealEstateModal/RealEstateForm/index.tsx
@@ -74,8 +74,8 @@ const RealEstateForm: FC<Props> = ({
 
   const isServiceExistById = (serviceId: string) => {
     if (!domain?.customServices?.length) return false
-  
-    return domain.customServices.some(group =>
+
+    return domain.customServices.some((group) =>
       group.services?.includes(serviceId)
     )
   }
@@ -96,7 +96,7 @@ const RealEstateForm: FC<Props> = ({
     )
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())[0]
 
-  const isMeterBasedServiceExist = 
+  const isMeterBasedServiceExist =
     isServiceExistById('677d414283b6ef93c6b8ea2c') ||
     isServiceExistById('682dd48d9665126611c81950')
 
@@ -147,23 +147,35 @@ const RealEstateForm: FC<Props> = ({
           disabled={!editable}
         />
       </Form.Item>
+
+      <Form.Item
+        name="currency"
+        label="Валюта"
+        rules={validateField('required')}
+      >
+        <Select
+          placeholder="Оберіть валюту"
+          className={s.formInput}
+          disabled={!editable}
+        >
+          <Select.Option value="UAH">UAH</Select.Option>
+          <Select.Option value="USD">USD</Select.Option>
+          <Select.Option value="EUR">EUR</Select.Option>
+        </Select>
+      </Form.Item>
       <EmailSelect form={form} disabled={!editable} required={false} />
-          <Form.Item
-            name="discount"
-            label="Знижка"
-            rules={validateField('number')}
-          >
-            <InputNumber
-              min={0}
-              max={100}
-              precision={2} 
-              formatter={(value) => `${value}`}
-              placeholder="Вкажіть знижку"
-              className={s.formInput}
-              disabled={!editable}
-              style={{ width: '100%' }}
-            />
-          </Form.Item>
+      <Form.Item name="discount" label="Знижка" rules={validateField('number')}>
+        <InputNumber
+          min={0}
+          max={100}
+          precision={2}
+          formatter={(value) => `${value}`}
+          placeholder="Вкажіть знижку"
+          className={s.formInput}
+          disabled={!editable}
+          style={{ width: '100%' }}
+        />
+      </Form.Item>
 
       {isMeterBasedServiceExist && (
         <>
@@ -191,29 +203,13 @@ const RealEstateForm: FC<Props> = ({
               disabled={!editable}
             />
           </Form.Item>
-          <Form.Item
-            name="currency"
-            label="Валюта"
-            rules={validateField('required')}
-          >
-            <Select
-              placeholder="Оберіть валюту"
-              className={s.formInput}
-              disabled={!editable}
-            >
-              <Select.Option value="UAH">UAH</Select.Option>
-              <Select.Option value="USD">USD</Select.Option>
-              <Select.Option value="EUR">EUR</Select.Option>
-            </Select>
-          </Form.Item>
-
-          <CustomServicesCard
-            form={form}
-            disabled={!editable}
-            allCustomServices={customServices}
-          />
         </>
       )}
+      <CustomServicesCard
+        form={form}
+        disabled={!editable}
+        allCustomServices={customServices}
+      />
 
       <Form.Item
         valuePropName="checked"

--- a/common/components/UI/RealEstateComponents/RealEstateModal/index.tsx
+++ b/common/components/UI/RealEstateComponents/RealEstateModal/index.tsx
@@ -16,6 +16,11 @@ import {
   useGetCustomServicesByDomainQuery,
 } from '@common/api/customServicesApi/customServices.api'
 
+const getEntityId = (value?: { _id?: string } | string) => {
+  if (!value) return ''
+  return typeof value === 'string' ? value : value._id || ''
+}
+
 interface Props {
   chosenRealEstate: { domain: string }
   closeModal: VoidFunction
@@ -35,7 +40,7 @@ const RealEstateModal: FC<Props> = ({
   const [addRealEstate] = useAddRealEstateMutation()
   const [editRealEstate] = useEditRealEstateMutation()
   const domainId = Form.useWatch('domain', form)
-  const currentDomainId = currentRealEstate?.domain?._id || domainId
+  const currentDomainId = getEntityId(currentRealEstate?.domain) || domainId
   const { data: customDomainServices } = useGetCustomServicesByDomainQuery(
     { domainId: currentDomainId },
     { skip: !currentDomainId }
@@ -63,7 +68,7 @@ const RealEstateModal: FC<Props> = ({
     form.setFieldsValue({
       domain:
         chosenRealEstate?.domain ||
-        currentRealEstate?.domain?._id ||
+        getEntityId(currentRealEstate?.domain) ||
         currentDomainId,
       street:
         currentRealEstate?.street &&
@@ -90,7 +95,7 @@ const RealEstateModal: FC<Props> = ({
     })
 
     initializedRef.current = true
-  }, [currentDomainId])
+  }, [currentDomainId, chosenRealEstate?.domain, currentRealEstate, form])
 
   const handleSubmit = async () => {
     const formData: IRealestate = await form.validateFields()

--- a/common/services/paymentService/payment.service.ts
+++ b/common/services/paymentService/payment.service.ts
@@ -207,6 +207,13 @@ export async function getPayments(
 
 export async function createPayment(body: any, isAdmin: boolean) {
   if (!isAdmin) throw new Error('not allowed')
+  if (body.invoiceCreationDate) {
+    const d = new Date(body.invoiceCreationDate)
+    body.invoiceCreationDate = new Date(
+      Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())
+    )
+  }
+
   const payment = await Payment.create(body)
 
   const description =

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,28 +1,28 @@
 import type { Config } from 'jest'
 import { pathsToModuleNameMapper } from 'ts-jest'
 import { compilerOptions } from './tsconfig.json'
-import { TextEncoder, TextDecoder } from 'util'
-
-global.TextEncoder = TextEncoder
-global.TextDecoder = TextDecoder
 
 const config: Config = {
-  testMatch: ['**/*.test.ts'],
+  preset: 'ts-jest',
+  testMatch: ['**/*.test.ts', '**/*.test.tsx'],
   testPathIgnorePatterns: ['/node_modules/', '/.next/'],
-  setupFiles: ['<rootDir>/jest.config.ts'],
-  testEnvironment: 'node',
-  transform: {
-    '^.+\\.ts?$': [
-      'ts-jest',
-      {
-        tsconfig: 'tsconfig.json',
-      },
-    ],
-  },
-  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
-    prefix: '<rootDir>/',
-  }),
-  moduleFileExtensions: ['ts', 'js'],
-}
+  testEnvironment: 'jsdom',
 
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json',
+    },
+  },
+
+  moduleNameMapper: {
+    ...pathsToModuleNameMapper(compilerOptions.paths, {
+      prefix: '<rootDir>/',
+    }),
+    '\\.(css|scss|sass)$': 'identity-obj-proxy',
+  },
+
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+}
 export default config

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom'
+import { TextEncoder, TextDecoder } from 'util'
+
+;(global as any).TextEncoder = TextEncoder
+;(global as any).TextDecoder = TextDecoder
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+})

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.47.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/big.js": "^6.2.2",
     "@types/crypto-js": "^4.2.2",
     "@types/jest": "^28.1.8",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "eslint-config-next": "12.1.6",
     "eslint-config-prettier": "^8.5.0",
     "husky": "^8.0.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^29.7.0",
     "mongodb-memory-server": "^8.14.0",

--- a/pages/api/auth/sign-up/sign-up.test.ts
+++ b/pages/api/auth/sign-up/sign-up.test.ts
@@ -28,6 +28,10 @@ describe('POST /api/auth/sign-up', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+  
 
   it('Should create new user', async () => {
     ;(User.findOne as jest.Mock).mockResolvedValue(null)

--- a/pages/api/bankapi/transactions/index.ts
+++ b/pages/api/bankapi/transactions/index.ts
@@ -28,22 +28,22 @@ export async function  checkTransaction({ transaction }) {
         //     ]
         //   }
         // },
-        {
-          $expr: {
-            $eq: [
-              { $trim: { input: { $ifNull: ['$transaction.AUT_CNTR_NAM', ''] } } },
-              Nam
-            ]
-          }
-        },
         // {
         //   $expr: {
         //     $eq: [
-        //       { $trim: { input: { $ifNull: ['$transaction.AUT_CNTR_MFO', ''] } } },
-        //       Mfo
+        //       { $trim: { input: { $ifNull: ['$transaction.AUT_CNTR_NAM', ''] } } },
+        //       Nam
         //     ]
         //   }
         // },
+        {
+          $expr: {
+            $eq: [
+              { $trim: { input: { $ifNull: ['$transaction.AUT_CNTR_MFO', ''] } } },
+              Mfo
+            ]
+          }
+        },
         { generalSum: Sum },
       ],
     })

--- a/pages/api/bankapi/transactions/index.ts
+++ b/pages/api/bankapi/transactions/index.ts
@@ -36,14 +36,14 @@ export async function  checkTransaction({ transaction }) {
             ]
           }
         },
-        {
-          $expr: {
-            $eq: [
-              { $trim: { input: { $ifNull: ['$transaction.AUT_CNTR_MFO', ''] } } },
-              Mfo
-            ]
-          }
-        },
+        // {
+        //   $expr: {
+        //     $eq: [
+        //       { $trim: { input: { $ifNull: ['$transaction.AUT_CNTR_MFO', ''] } } },
+        //       Mfo
+        //     ]
+        //   }
+        // },
         { generalSum: Sum },
       ],
     })

--- a/pages/api/bankapi/transactions/index.ts
+++ b/pages/api/bankapi/transactions/index.ts
@@ -28,22 +28,22 @@ export async function  checkTransaction({ transaction }) {
         //     ]
         //   }
         // },
-        // {
-        //   $expr: {
-        //     $eq: [
-        //       { $trim: { input: { $ifNull: ['$transaction.AUT_CNTR_NAM', ''] } } },
-        //       Nam
-        //     ]
-        //   }
-        // },
-        // {
-        //   $expr: {
-        //     $eq: [
-        //       { $trim: { input: { $ifNull: ['$transaction.AUT_CNTR_MFO', ''] } } },
-        //       Mfo
-        //     ]
-        //   }
-        // },
+        {
+          $expr: {
+            $eq: [
+              { $trim: { input: { $ifNull: ['$transaction.AUT_CNTR_NAM', ''] } } },
+              Nam
+            ]
+          }
+        },
+        {
+          $expr: {
+            $eq: [
+              { $trim: { input: { $ifNull: ['$transaction.AUT_CNTR_MFO', ''] } } },
+              Mfo
+            ]
+          }
+        },
         { generalSum: Sum },
       ],
     })

--- a/pages/api/constructor-doc/index.tsx
+++ b/pages/api/constructor-doc/index.tsx
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import start, { Data } from '@pages/api/api.config'
+
+start()
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+) {
+  switch (req.method) {
+    case 'POST':
+      try {
+        const { domainId, meta, authTag } = req.body
+
+        return res.status(201).json({ success: true, data: { domainId, meta, authTag } })
+      } catch (error) {
+        return res.status(400).json({ success: false, error: error })
+      }
+  }
+}

--- a/pages/api/real-estate/index.ts
+++ b/pages/api/real-estate/index.ts
@@ -19,8 +19,13 @@ export default async function handler(
   switch (req.method) {
     case 'GET':
       try {
-        const { companyId, domainId, streetId, archived, limit = 0 } = req.query
+        const { companyId, domainId, streetId, archived, services, limit = 0 } = req.query
 
+        const servicesIds: string[] | null = services
+          ? typeof services === 'string'
+            ? services.split(',').map((id) => decodeURIComponent(id))
+            : (services as string[]).map((id) => decodeURIComponent(id))
+          : null
         const companiesIds: string[] | null = companyId
           ? typeof companyId === 'string'
             ? companyId.split(',').map((id) => decodeURIComponent(id))
@@ -47,6 +52,23 @@ export default async function handler(
           ...(!!companiesIds?.length && { _id: { $in: companiesIds } }),
           ...(!!domainsIds?.length && { domain: { $in: domainsIds } }),
           ...(!!streetsIds?.length && { street: { $in: streetsIds } }),
+        }
+
+        if (servicesIds && servicesIds.length > 0) {
+          filters.$or = servicesIds.map((serviceKey) => {
+            if (['cleaning', 'totalArea', 'pricePerMeter', 'waterPart'].includes(serviceKey)) {
+              return { [serviceKey]: { $gt: 0 } }
+            }
+            if (['garbageCollector', 'inflicion'].includes(serviceKey)) {
+              return { [serviceKey]: true }
+            }
+            return {
+              $or: [
+                { services: { $elemMatch: { $or: [{ _id: serviceKey }, { serviceId: serviceKey }, { service: serviceKey }] } } },
+                { customServices: { $elemMatch: { $or: [{ _id: serviceKey }, { serviceId: serviceKey }, { service: serviceKey }] } } }
+              ]
+            }
+          })
         }
 
         /**

--- a/pages/api/user/[id]/index.ts
+++ b/pages/api/user/[id]/index.ts
@@ -40,18 +40,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         if (isSelf && isRoleUpdate && !isGlobalAdmin) {
           return res.status(403).json({ success: false, message: 'not allowed' })
         }
-        if (isSelf && isRoleUpdate && isGlobalAdmin) {
-          const nextRoles = req.body.roles ?? (req.body.role ? [req.body.role] : [])
-          const willLoseGlobal =
-            Array.isArray(nextRoles) && !nextRoles.includes(Roles.GLOBAL_ADMIN)
-
-          if (willLoseGlobal) {
-            return res.status(403).json({
-              success: false,
-              message: "You can't remove GLOBAL_ADMIN from yourself",
-            })
-          }
-        }
 
         const updatedUser = await User.updateOne({ _id: targetId }, req.body)
 

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/utils/getInvoices/index.ts
+++ b/utils/getInvoices/index.ts
@@ -285,7 +285,7 @@ export const getElectricityInvoice = ({
 
     return {
       type: ServiceType.Electricity,
-      amount: +toRoundFixed(prevElectricity?.amount),
+      amount: 0,
       lastAmount: +toRoundFixed(prevElectricity?.amount),
       losses: +toRoundFixed(service?.losses) || undefined,
       price: +toRoundFixed(service.electricityPrice),

--- a/utils/helpers/index.ts
+++ b/utils/helpers/index.ts
@@ -351,6 +351,48 @@ export function currencyWithUnit(
   return `${value} ${label}${unit ? `/${unit}` : ''}`
 }
 
+export const normalizeCurrency = (currency?: string): 'UAH' | 'USD' | 'EUR' => {
+  const normalizedCurrency = currency?.toUpperCase()
+
+  if (normalizedCurrency === 'USD' || normalizedCurrency === 'EUR') {
+    return normalizedCurrency
+  }
+
+  return 'UAH'
+}
+
+export const getCurrencyShortLabel = (currency?: string): string => {
+  const normalizedCurrency = normalizeCurrency(currency)
+
+  return {
+    UAH: 'грн',
+    USD: 'USD',
+    EUR: 'EUR',
+  }[normalizedCurrency]
+}
+
+export const getCurrencySymbol = (currency?: string): string => {
+  const normalizedCurrency = normalizeCurrency(currency)
+
+  return {
+    UAH: '₴',
+    USD: '$',
+    EUR: '€',
+  }[normalizedCurrency]
+}
+
+export const getCurrencyNames = (
+  currency?: string
+): { major: string; minor: string } => {
+  const normalizedCurrency = normalizeCurrency(currency)
+
+  return {
+    UAH: { major: 'гривень', minor: 'копійок' },
+    USD: { major: 'доларів', minor: 'центів' },
+    EUR: { major: 'євро', minor: 'центів' },
+  }[normalizedCurrency]
+}
+
 
 export function multiplyFloat(a, b) {
   const bigA = Big(toRoundFixed(`${a}`))

--- a/yarn.lock
+++ b/yarn.lock
@@ -6833,6 +6833,11 @@ gsap@^3.13.0:
   resolved "https://registry.yarnpkg.com/gsap/-/gsap-3.13.0.tgz#597d4e019a2bb487785387d91296adebf92db9dd"
   integrity sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==
 
+harmony-reflect@^1.4.6:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
+  integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
+
 has-bigints@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.1.0.tgz#28607e965ac967e03cd2a2c70a2636a1edad49fe"
@@ -7004,6 +7009,13 @@ idb@^7.0.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/idb/-/idb-7.1.1.tgz#d910ded866d32c7ced9befc5bfdf36f572ced72b"
   integrity sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3626,6 +3626,11 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@testing-library/user-event@^14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
+  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
+
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches both frontend and backend query/filter logic (real-estate `services` filtering) and changes payment date handling to UTC, which could affect returned datasets and persisted invoice dates. Also updates user role update constraints and transaction matching logic, so regressions could impact admin workflows.
> 
> **Overview**
> **Real estate listings can now be filtered by selected services.** The `getAllRealEstate` RTK query and `/api/real-estate` GET endpoint accept a new `services` query param and apply it via `$or` conditions across standard service fields and `services`/`customServices` arrays; the Companies dashboard adds a multi-select UI for this filter and the Companies table dynamically shows only the chosen service columns.
> 
> **Payment/receipt UX and formatting were updated.** Payments now normalize `invoiceCreationDate` to UTC on both the client submit path and server `createPayment`, invoice defaults avoid overwriting when editing/changing companies, and a missing discount line item is auto-added from `company.discount`. Receipts/acts now render currency symbols/labels and switch key strings to English when currency isn’t UAH; grouped tables also receive currency to adjust headers.
> 
> **Misc fixes and test infrastructure.** Electricity losses display is rounded and bulk/electricity helpers avoid showing loss calcs for zero usage; payment filtering preserves `street` on filter changes and guards against null `domain`/`company` fields. Jest was switched to `jsdom` with TSX support and setup helpers, and new component tests were added (dashboard layout, domains table, companies table column visibility, custom services card).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20b2825e7ac7b9ef18ff7afe0d2901d9bceaa496. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->