### PR TITLE
fix: match company by rnokpp in description field

### DIFF
--- a/common/components/Pages/BankTransactions/components/TransactionsTable/components/bankHelper.test.tsx
+++ b/common/components/Pages/BankTransactions/components/TransactionsTable/components/bankHelper.test.tsx
@@ -105,6 +105,39 @@ describe('matchByRnokpp', () => {
 
         expect(matchByRnokpp(transaction, mockCompanies)).toBeNull()
     })
+
+    it('should match by rnokpp found in company description', () => {
+        const companyWithRnokppInDescription: IRealestate = {
+            _id: 'kincal-desc-id',
+            companyName: 'Vocal Kincal',
+            account: '',
+            rnokpp: '',
+            description: 'Юлія Кінцал\nм. Житомир\nвул. Кибальчича 4\n3042507187\n+380671511260',
+        } as IRealestate
+
+        const transaction = {
+            AUT_CNTR_ACC: 'UA293052990000029023866100110',
+            AUT_CNTR_NAM: 'Транз.рахунок платежi_ DN, DG, DZ',
+            RECIPIENT_ULTMT_NCEO: '3042507187',
+        } as ITransaction
+
+        expect(matchByRnokpp(transaction, [companyWithRnokppInDescription])).toEqual({
+            companyId: 'kincal-desc-id',
+            matchedBy: 'rnokpp',
+        })
+    })
+
+    it('should prioritize rnokpp field over description', () => {
+        const byField: IRealestate = { _id: 'by-field', companyName: 'A', account: '', rnokpp: '3042507187' } as IRealestate
+        const byDesc: IRealestate = { _id: 'by-desc', companyName: 'B', account: '', rnokpp: '', description: '3042507187' } as IRealestate
+
+        const transaction = { RECIPIENT_ULTMT_NCEO: '3042507187' } as ITransaction
+
+        expect(matchByRnokpp(transaction, [byField, byDesc])).toEqual({
+            companyId: 'by-field',
+            matchedBy: 'rnokpp',
+        })
+    })
 })
 
 describe('matchByPrevious', () => {

--- a/common/components/Pages/BankTransactions/components/TransactionsTable/components/bankHelper.ts
+++ b/common/components/Pages/BankTransactions/components/TransactionsTable/components/bankHelper.ts
@@ -25,8 +25,9 @@ export const matchByRnokpp = (
   companies: IRealestate[]
 ): MatchResult | null => {
   if (!transaction.RECIPIENT_ULTMT_NCEO) return null
+  const nceo = transaction.RECIPIENT_ULTMT_NCEO
   const company = companies.find(
-    (c) => c.rnokpp && c.rnokpp === transaction.RECIPIENT_ULTMT_NCEO
+    (c) => (c.rnokpp && c.rnokpp === nceo) || c.description?.includes(nceo)
   )
   return company ? { companyId: company._id!, matchedBy: MatchType.RNOKPP } : null
 }


### PR DESCRIPTION
Extends matchByRnokpp to also search company description when rnokpp field is empty, allowing transit transactions to match companies that store their RNOKPP only in the description text.