### PR TITLE
Branch1

### DIFF
--- a/common/components/Tables/Companies/Header.tsx
+++ b/common/components/Tables/Companies/Header.tsx
@@ -152,25 +152,25 @@ const CompaniesHeader: React.FC<Props> = ({
           ]}
           onChange={handleArchiveToggle}
         />
-
-        {showAddButton && isAdmin && (
-          <>
-            <Button type="link" onClick={openModal} className={s.addButton}>
-              <PlusOutlined /> Додати
-            </Button>
-            {(isModalOpen || currentRealEstate) && (
-              <RealEstateModal
-                closeModal={closeModal}
-                chosenRealEstate={
-                  filters?.domain ? { domain: filters?.domain[0] } : null
-                }
-                currentRealEstate={currentRealEstate}
-                editable={realEstateActions.edit}
-              />
-            )}
-          </>
-        )}
       </div>
+
+      {showAddButton && isAdmin && (
+        <>
+          <Button type="link" onClick={openModal} className={s.addButton}>
+            <PlusOutlined /> Додати
+          </Button>
+          {(isModalOpen || currentRealEstate) && (
+            <RealEstateModal
+              closeModal={closeModal}
+              chosenRealEstate={
+                filters?.domain ? { domain: filters?.domain[0] } : null
+              }
+              currentRealEstate={currentRealEstate}
+              editable={realEstateActions.edit}
+            />
+          )}
+        </>
+      )}
     </div>
   )
 }

--- a/common/components/Tables/Companies/Header.tsx
+++ b/common/components/Tables/Companies/Header.tsx
@@ -58,7 +58,7 @@ const CompaniesHeader: React.FC<Props> = ({
 
   const { data: customServicesResponse } = useGetCustomServicesQuery({})
   const customServices = customServicesResponse?.data || []
-  
+
   const { data: user } = useGetCurrentUserQuery()
   const isAdmin = isAdminCheck(user?.roles)
 
@@ -86,11 +86,11 @@ const CompaniesHeader: React.FC<Props> = ({
   })
 
   const handleServicesChange = (values: string[]) => {
-  setFilters((prev: any) => ({
-    ...prev,
-    services: values,
-  }))
-}
+    setFilters((prev: any) => ({
+      ...prev,
+      services: values,
+    }))
+  }
 
   return (
     <div className={s.headerBlock}>
@@ -122,29 +122,29 @@ const CompaniesHeader: React.FC<Props> = ({
             />
           </Space>
         )}
-      <div style={{ position: 'absolute', left: 400,}}>
-      <Select
-        mode="multiple"
-        allowClear
-        placeholder="Фільтр послуг"
-        style={{ width: "250px" }}
-        value={filters?.services || []}
-        onChange={handleServicesChange}
-        maxTagCount="responsive"
-      >
-        {customServices.length > 0 && (
-        <Select.OptGroup label="Кастомні">
-          {customServices.map((service) => (
-            <Select.Option key={service._id} value={service._id}>
-              {service.name}
-            </Select.Option>
-        ))}
-        </Select.OptGroup>
-      )}
-    </Select>
-    </div>  
       </div>
+
       <div className={s.segmented}>
+        <Select
+          mode="multiple"
+          allowClear
+          placeholder="Фільтр послуг"
+          style={{ width: "250px", minWidth: "150px" }}
+          value={filters?.services || []}
+          onChange={handleServicesChange}
+          maxTagCount="responsive"
+        >
+          {customServices.length > 0 && (
+            <Select.OptGroup label="Кастомні">
+              {customServices.map((service) => (
+                <Select.Option key={service._id} value={service._id}>
+                  {service.name}
+                </Select.Option>
+              ))}
+            </Select.OptGroup>
+          )}
+        </Select>
+
         <Segmented
           options={[
             { label: 'Неархівовані', value: false },
@@ -152,25 +152,25 @@ const CompaniesHeader: React.FC<Props> = ({
           ]}
           onChange={handleArchiveToggle}
         />
-      </div>
 
-      {showAddButton && isAdmin && (
-        <>
-          <Button type="link" onClick={openModal}>
-            <PlusOutlined /> Додати
-          </Button>
-          {(isModalOpen || currentRealEstate) && (
-            <RealEstateModal
-              closeModal={closeModal}
-              chosenRealEstate={
-                filters?.domain ? { domain: filters?.domain[0] } : null
-              }
-              currentRealEstate={currentRealEstate}
-              editable={realEstateActions.edit}
-            />
-          )}
-        </>
-      )}
+        {showAddButton && isAdmin && (
+          <>
+            <Button type="link" onClick={openModal} className={s.addButton}>
+              <PlusOutlined /> Додати
+            </Button>
+            {(isModalOpen || currentRealEstate) && (
+              <RealEstateModal
+                closeModal={closeModal}
+                chosenRealEstate={
+                  filters?.domain ? { domain: filters?.domain[0] } : null
+                }
+                currentRealEstate={currentRealEstate}
+                editable={realEstateActions.edit}
+              />
+            )}
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/common/components/Tables/Companies/style.module.scss
+++ b/common/components/Tables/Companies/style.module.scss
@@ -16,6 +16,7 @@
   gap: 8px;
   margin-top: 3px;
   margin-bottom: 5px;
+  margin-right: -100px;
 }
 
 .segmented {
@@ -26,12 +27,38 @@
   margin-bottom: 16px;
   margin-top: 12px;
   margin-left: auto;
-
-  @media (max-width: 768px) {
-    width: 100%;
-  }
+  margin-right: auto;
 }
 
 .addButton {
   margin-left: auto;
+}
+
+@media (max-width: 992px) {
+  .firstBlock {
+    width: 100%;
+    margin-bottom: 8px;
+  }
+
+  .segmented {
+    flex: 1;
+    justify-content: center;
+  }
+
+  .addButton {
+    margin-left: auto;
+  }
+}
+
+@media (max-width: 576px) {
+  .segmented {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .addButton {
+    width: 100%;
+    justify-content: flex-end;
+    margin-top: 12px;
+  }
 }

--- a/common/components/Tables/Companies/style.module.scss
+++ b/common/components/Tables/Companies/style.module.scss
@@ -1,17 +1,37 @@
 .headerBlock {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
+  gap: 8px;
+  width: 100%;
+  white-space: normal;
 }
 
 .firstBlock {
   display: flex;
   flex-direction: row;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 3px;
+  margin-bottom: 5px;
 }
 
 .segmented {
   display: flex;
   align-items: center;
-  margin-right: 120px;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+  margin-top: 12px;
+  margin-left: auto;
+
+  @media (max-width: 768px) {
+    width: 100%;
+  }
+}
+
+.addButton {
+  margin-left: auto;
 }

--- a/common/components/UI/PaymentCardHeader/styles.module.scss
+++ b/common/components/UI/PaymentCardHeader/styles.module.scss
@@ -234,7 +234,7 @@
 
 .tags {
   white-space: nowrap;
-      min-width: 200px;
+  min-width: 200px;
 
   @media (min-width: 320px) and (max-width: 375px) {
     margin-left: -15px;

--- a/common/components/UI/PaymentCardHeader/styles.module.scss
+++ b/common/components/UI/PaymentCardHeader/styles.module.scss
@@ -110,6 +110,8 @@
 
 .section {
   width: 100%;
+  flex-wrap: wrap;
+  justify-content: space-between;
 }
 
 .selectors {
@@ -231,7 +233,8 @@
 }
 
 .tags {
-  width: 100%;
+  white-space: nowrap;
+      min-width: 200px;
 
   @media (min-width: 320px) and (max-width: 375px) {
     margin-left: -15px;


### PR DESCRIPTION
Margin between filters
Пофіксила адаптивність блоку з тегами. Раніше при звуженні екрана текст ламався і верстка «їхала». Тепер текст є цілим, він вирівнюється по правому краю, а на малих екранах плавно і цілком переноситься на новий рядок під блок із селектами
<img width="1280" height="390" alt="image_2026-04-23_13-41-02" src="https://github.com/user-attachments/assets/456ef988-61d8-4579-8f86-9ef7a232ad3d" />
<img width="863" height="494" alt="image_2026-04-23_13-42-43" src="https://github.com/user-attachments/assets/6391b151-47e4-4ff6-96ef-27e4cf292eb4" />
<img width="875" height="576" alt="image_2026-04-23_13-44-19" src="https://github.com/user-attachments/assets/fa63136a-8935-423b-9d25-4aca34c1cc7b" />
<img width="1280" height="442" alt="image_2026-04-23_13-58-11" src="https://github.com/user-attachments/assets/6f341535-93ad-4db9-a03c-6b33902ba5cb" />
<img width="1280" height="235" alt="image_2026-04-23_14-00-01" src="https://github.com/user-attachments/assets/de98e83d-801e-48b2-9230-0648c21f4ec4" />
