### PR TITLE
fix: move currency selector next to invoice number

### DIFF
--- a/common/assets/features/formatDate.test.ts
+++ b/common/assets/features/formatDate.test.ts
@@ -1,0 +1,49 @@
+import { formatInvoiceDate, formatInvoiceDueDate } from './formatDate'
+
+describe('formatInvoiceDate', () => {
+  it('форматує Date в DD.MM.YYYY', () => {
+    expect(formatInvoiceDate(new Date('2024-03-15'))).toBe('15.03.2024')
+  })
+
+  it('форматує рядок ISO в DD.MM.YYYY', () => {
+    expect(formatInvoiceDate('2024-01-05T00:00:00.000Z')).toBe('05.01.2024')
+  })
+
+  it('повертає порожній рядок для undefined', () => {
+    expect(formatInvoiceDate(undefined)).toBe('')
+  })
+
+  it('повертає порожній рядок для null', () => {
+    expect(formatInvoiceDate(null)).toBe('')
+  })
+
+  it('повертає порожній рядок для невалідної дати', () => {
+    expect(formatInvoiceDate('not-a-date')).toBe('')
+  })
+})
+
+describe('formatInvoiceDueDate', () => {
+  it('додає 5 днів і форматує в DD.MM.YYYY за замовчуванням', () => {
+    expect(formatInvoiceDueDate(new Date('2024-03-15'))).toBe('20.03.2024')
+  })
+
+  it('додає задану кількість днів', () => {
+    expect(formatInvoiceDueDate(new Date('2024-03-15'), 10)).toBe('25.03.2024')
+  })
+
+  it('коректно переходить через межу місяця', () => {
+    expect(formatInvoiceDueDate(new Date('2024-01-29'))).toBe('03.02.2024')
+  })
+
+  it('повертає порожній рядок для undefined', () => {
+    expect(formatInvoiceDueDate(undefined)).toBe('')
+  })
+
+  it('повертає порожній рядок для null', () => {
+    expect(formatInvoiceDueDate(null)).toBe('')
+  })
+
+  it('повертає порожній рядок для невалідної дати', () => {
+    expect(formatInvoiceDueDate('not-a-date')).toBe('')
+  })
+})

--- a/common/assets/features/formatDate.ts
+++ b/common/assets/features/formatDate.ts
@@ -40,3 +40,15 @@ export const getPreviousMonth = (date?: string) => {
 export const getFormattedDate = (date: Date, format = 'MMMM'): string => {
   return toFirstUpperCase(dayjs(date).format(format))
 }
+
+export const formatInvoiceDate = (date?: Date | string | null): string => {
+  if (!date) return ''
+  const d = dayjs(date)
+  return d.isValid() ? d.format('DD.MM.YYYY') : ''
+}
+
+export const formatInvoiceDueDate = (date?: Date | string | null, days = 5): string => {
+  if (!date) return ''
+  const d = dayjs(date)
+  return d.isValid() ? d.add(days, 'd').format('DD.MM.YYYY') : ''
+}

--- a/common/components/Forms/AddPaymentForm/PaymentTotal.tsx
+++ b/common/components/Forms/AddPaymentForm/PaymentTotal.tsx
@@ -1,5 +1,6 @@
-import { Operations, CURRENCY_SELECT_OPTIONS } from '@utils/constants'
-import { Form, FormInstance, Select } from 'antd'
+import { Operations } from '@utils/constants'
+import { getCurrencyShortLabel } from '@utils/helpers'
+import { Form, FormInstance } from 'antd'
 import { FC, useEffect } from 'react'
 import s from './style.module.scss'
 
@@ -10,6 +11,8 @@ interface Props {
 const PaymentTotal: FC<Props> = ({ form }) => {
   const invoices = Form.useWatch(['invoice'], form)
   const total = Form.useWatch(Operations.Debit, form)
+  const currency = Form.useWatch('currency', form)
+  const currencyLabel = getCurrencyShortLabel(currency)
 
   useEffect(() => {
     const newTotal = Object.entries<{ sum: number }>(invoices || []).reduce(
@@ -25,16 +28,8 @@ const PaymentTotal: FC<Props> = ({ form }) => {
       name={Operations.Debit}
       initialValue={0}
     >
-    <div className={s.sumRow}>
-      <span>Сума: {(+total)?.toFixed(2)}</span>
-      <Form.Item name="currency" noStyle>
-        <Select
-          className={s.currencySelect}
-          options={CURRENCY_SELECT_OPTIONS}
-        />
-      </Form.Item>
-    </div>
-  </Form.Item>
+      <span>Сума: {(+total)?.toFixed(2)} {currencyLabel}</span>
+    </Form.Item>
   )
 }
 

--- a/common/components/Forms/AddPaymentForm/index.tsx
+++ b/common/components/Forms/AddPaymentForm/index.tsx
@@ -71,7 +71,7 @@ function AddPaymentForm({
 
   useEffect(() => {
     if (!changelogId) return
-    
+
     const exists = changelogOptions.some(opt => opt.value === changelogId)
     if (!exists) {
       form.setFieldValue('changelogId', undefined)
@@ -86,8 +86,8 @@ function AddPaymentForm({
     prevPayment,
   })
   const showCurrentVersionBtn = !!changelogId
-  
-  
+
+
   const showChangelog = changelogOptions.length > 0
 
   return (
@@ -102,58 +102,56 @@ function AddPaymentForm({
       <MonthServiceSelect form={form} edit={edit} />
       <CompanySelect form={form} edit={edit} company={payment?.company} />
       <PaymentTypeSelect edit={!companyId || edit} />
-      <InvoiceNumber form={form} paymentActions={selectedActions} />
-      <InvoiceCreationDate edit={preview} />
-      
-    {!preview && operation !== Operations.Credit && showChangelog ? (
-      <div className={changelogRowStyles.changelogRow}>
-        <div className={changelogRowStyles.changelogSelect}>
-          <Form.Item
-            name="changelogId"
-            label="Історія змін"
-            tooltip="Попередні версії рахунку. Зберігаються автоматично після кожного редагування."
-          >
-            <Select
-              allowClear
-              placeholder="Оберіть версію рахунку"
-              options={changelogOptions}
-              optionLabelProp="shortLabel"
-              loading={changelogLoading}
-              disabled={preview}
-              notFoundContent={
-                changelogLoading ? 'Завантаження...' : 'Історії змін ще немає'
-              }
-            />
-          </Form.Item>
-        </div>
+      <div className={s.invoiceRow}>
+        <InvoiceNumber form={form} paymentActions={selectedActions} />
+        <Form.Item name="currency" label=" ">
+          <Select
+            className={s.currencySelect}
+            options={CURRENCY_SELECT_OPTIONS}
+            disabled={preview}
+          />
+        </Form.Item>
       </div>
-    ) : null}
+      <InvoiceCreationDate edit={preview} />
 
-      {operation === Operations.Credit ? (
-        <>
-        <Form.Item label="Сума" required>
-          <div className={s.sumRow}>
+      {!preview && operation !== Operations.Credit && showChangelog ? (
+        <div className={changelogRowStyles.changelogRow}>
+          <div className={changelogRowStyles.changelogSelect}>
             <Form.Item
-              name="generalSum"
-              noStyle
-              rules={validateField('paymentPrice')}
+              name="changelogId"
+              label="Історія змін"
+              tooltip="Попередні версії рахунку. Зберігаються автоматично після кожного редагування."
             >
-              <InputNumber
-                parser={inputNumberParser}
-                style={{ width: 160 }}
-                placeholder="Вкажіть суму"
-                disabled={preview}
-              />
-            </Form.Item>
-            <Form.Item name="currency" noStyle>
               <Select
-                className={s.currencySelect}
-                options={CURRENCY_SELECT_OPTIONS}
+                allowClear
+                placeholder="Оберіть версію рахунку"
+                options={changelogOptions}
+                optionLabelProp="shortLabel"
+                loading={changelogLoading}
                 disabled={preview}
+                notFoundContent={
+                  changelogLoading ? 'Завантаження...' : 'Історії змін ще немає'
+                }
               />
             </Form.Item>
           </div>
-        </Form.Item>
+        </div>
+      ) : null}
+
+      {operation === Operations.Credit ? (
+        <>
+          <Form.Item
+            name="generalSum"
+            label="Сума"
+            rules={validateField('paymentPrice')}
+          >
+            <InputNumber
+              parser={inputNumberParser}
+              style={{ width: 160 }}
+              placeholder="Вкажіть суму"
+              disabled={preview}
+            />
+          </Form.Item>
           <Form.Item
             name="description"
             label="Опис"

--- a/common/components/Forms/AddPaymentForm/style.module.scss
+++ b/common/components/Forms/AddPaymentForm/style.module.scss
@@ -5,10 +5,6 @@
     align-items: center;
   }
 
-  .currencySelect {
-    width: 90px;
-  }
-
   .inputNumber {
     width: 100%;
   }
@@ -31,4 +27,14 @@
     font-size: 1.25rem;
     margin-top: 1rem;
   }
+}
+
+.invoiceRow {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.currencySelect {
+  width: 50px;
 }

--- a/common/components/Forms/GroupedReceiptForm/index.tsx
+++ b/common/components/Forms/GroupedReceiptForm/index.tsx
@@ -9,7 +9,7 @@ import { FC, useRef } from 'react'
 import { useReactToPrint } from 'react-to-print'
 import {
   PrinterOutlined,
-  EditOutlined,
+  LayoutOutlined,
   RightOutlined,
   CheckOutlined,
   TableOutlined,
@@ -301,7 +301,7 @@ const GroupedReceiptForm: FC<Props> = ({
         }}
       >
         <Tooltip title={isEnglish ? 'Select template' : 'Обрати шаблон'}>
-          <EditOutlined className={s.edit} />
+          <LayoutOutlined className={s.edit} />
         </Tooltip>
       </Dropdown>
       <Tooltip title="Показувати кількість і ціну в таблиці перегляду">

--- a/common/components/Forms/GroupedReceiptForm/templates/classic/index.tsx
+++ b/common/components/Forms/GroupedReceiptForm/templates/classic/index.tsx
@@ -43,6 +43,7 @@ const ClassicTemplate: FC<TemplateProps> = ({
     <div className={cs.receiverInfo}>
       <div className={cs.label}>{isEnglish ? 'Recipient' : 'Одержувач'}</div>
       <pre className={cs.preLabel}>
+        {data?.reciever?.companyName && <><strong>{data.reciever.companyName}</strong>{'\n'}</>}
         {data?.reciever?.description?.trim()} <br />
         {data?.reciever?.adminEmails?.map((email: string) => (
           <div key={email}>

--- a/common/components/Forms/GroupedReceiptForm/templates/classic/index.tsx
+++ b/common/components/Forms/GroupedReceiptForm/templates/classic/index.tsx
@@ -95,17 +95,16 @@ const ClassicTemplate: FC<TemplateProps> = ({
         <strong>
           {isEnglish
             ? `Payment for services according to invoice № ${data.invoiceNumber} dated ${dayjs(
-                data?.invoiceCreationDate
-              )?.format?.('DD.MM.YYYY')}`
+              data?.invoiceCreationDate
+            )?.format?.('DD.MM.YYYY')}`
             : `Оплата за послуги згідно рахунку № ${data.invoiceNumber} від ${dayjs(
-                data?.invoiceCreationDate
-              )?.format?.('DD.MM.YYYY')}`}
+              data?.invoiceCreationDate
+            )?.format?.('DD.MM.YYYY')}`}
         </strong>
       </div>
 
       <div className={cs.payFixed}>
-        {data?.provider?.description?.split('\n')?.[0] || ''}
-        {/* <div className={cs.lineInner}>________________</div> */}
+        {data?.domain?.name || data?.provider?.description?.split('\n')?.[0] || ''}
       </div>
     </div>
   </div>

--- a/common/components/Forms/GroupedReceiptForm/templates/classic/index.tsx
+++ b/common/components/Forms/GroupedReceiptForm/templates/classic/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
-import dayjs from 'dayjs'
 import GroupedPricesTable from '@components/Forms/GroupedReceiptForm/GroupedPricesTable'
+import { formatInvoiceDate, formatInvoiceDueDate } from '@common/assets/features/formatDate'
 import { TemplateProps } from '../types'
 import cs from './style.module.scss'
 
@@ -59,12 +59,12 @@ const ClassicTemplate: FC<TemplateProps> = ({
       </div>
       <div className={cs.datecellDate}>
         {isEnglish ? 'Dated' : 'Від'} &nbsp;
-        {dayjs(data?.invoiceCreationDate)?.format?.('DD.MM.YYYY')}
+        {formatInvoiceDate(data?.invoiceCreationDate)}
         {isEnglish ? '.' : ' року.'}
       </div>
       <div className={cs.datecell}>
         {isEnglish ? 'Due by' : 'Підлягає сплаті до'} &nbsp;
-        {dayjs(data?.invoiceCreationDate).add(5, 'd').format('DD.MM.YYYY')}
+        {formatInvoiceDueDate(data?.invoiceCreationDate)}
         {!isEnglish && (
           <>
             &nbsp; року
@@ -96,12 +96,8 @@ const ClassicTemplate: FC<TemplateProps> = ({
         {isEnglish ? 'Payment purpose:' : 'Призначення платежу:'}{' '}
         <strong>
           {isEnglish
-            ? `Payment for services according to invoice № ${data.invoiceNumber} dated ${dayjs(
-              data?.invoiceCreationDate
-            )?.format?.('DD.MM.YYYY')}`
-            : `Оплата за послуги згідно рахунку № ${data.invoiceNumber} від ${dayjs(
-              data?.invoiceCreationDate
-            )?.format?.('DD.MM.YYYY')}`}
+            ? `Payment for services according to invoice № ${data.invoiceNumber} dated ${formatInvoiceDate(data?.invoiceCreationDate)}`
+            : `Оплата за послуги згідно рахунку № ${data.invoiceNumber} від ${formatInvoiceDate(data?.invoiceCreationDate)}`}
         </strong>
       </div>
 

--- a/common/components/Forms/GroupedReceiptForm/templates/classic/index.tsx
+++ b/common/components/Forms/GroupedReceiptForm/templates/classic/index.tsx
@@ -34,6 +34,7 @@ const ClassicTemplate: FC<TemplateProps> = ({
     <div className={cs.providerInfo}>
       <div className={cs.label}>{isEnglish ? 'Provider' : 'Постачальник'}</div>
       <pre className={cs.preLabel}>
+        {data?.domain?.name && <><strong>{data.domain.name}</strong>{'\n'}</>}
         {data?.provider?.description?.trim()} <br />
         <br />
       </pre>


### PR DESCRIPTION
…ate domain name

- Move currency select from credit sum row and PaymentTotal to a single location inline with the invoice number field
- PaymentTotal now reads currency via useWatch and displays label as text
- Add .invoiceRow flex container with top-level CSS module classes
- Classic template: show domain name instead of sliced provider description