### PR TITLE
fix(domain): preserve PrivatBank tokens on unrelated edits

### DIFF
--- a/common/components/UI/DomainsComponents/DomainModal/DomainForm/tabs/BankTab.tsx
+++ b/common/components/UI/DomainsComponents/DomainModal/DomainForm/tabs/BankTab.tsx
@@ -1,6 +1,6 @@
 import { useGetDomainsQuery } from '@common/api/domainApi/domain.api'
 import { CloseOutlined } from '@ant-design/icons'
-import { Button, Card, Form, Input, Select, Space } from 'antd'
+import { Button, Card, Form, Input, Popconfirm, Select, Space } from 'antd'
 import { FC, useMemo } from 'react'
 import s from '../style.module.scss'
 import type { TabProps } from './types'
@@ -31,9 +31,17 @@ const BankTab: FC<TabProps> = ({ form, editable }) => {
               aria-disabled={!editable}
               extra={
                 editable && (
-                  <Button type="link" onClick={() => remove(field.name)}>
-                    <CloseOutlined />
-                  </Button>
+                  <Popconfirm
+                    title="Видалити токен?"
+                    description="Інтеграція з банком для цього домена перестане працювати."
+                    okText="Так, видалити"
+                    cancelText="Скасувати"
+                    onConfirm={() => remove(field.name)}
+                  >
+                    <Button type="link">
+                      <CloseOutlined />
+                    </Button>
+                  </Popconfirm>
                 )
               }
             >

--- a/pages/api/domain/[id]/index.ts
+++ b/pages/api/domain/[id]/index.ts
@@ -19,18 +19,60 @@ export default async function handler(
 
   const SECURE_TOKEN = process.env.NEXT_PUBLIC_MONGODB_SECRET_TOKEN
 
-  function encryptDomainBankTokens(obj: any, secretKey: string) {
-    if (!obj.domainBankToken || !Array.isArray(obj.domainBankToken)) {
+  async function encryptDomainBankTokens(
+    obj: any,
+    secretKey: string,
+    domainId: string
+  ) {
+    // If the form didn't carry tokens at all, leave existing ones alone.
+    // This guards against an undefined / '' / [] body field silently
+    // wiping a domain's PrivatBank integration on any unrelated PATCH.
+    if (
+      !Array.isArray(obj.domainBankToken) ||
+      obj.domainBankToken.length === 0
+    ) {
+      delete obj.domainBankToken
       return obj
     }
 
     const encryptionService = new EncryptionService(secretKey)
 
-    obj.domainBankToken = obj.domainBankToken.map((item) => ({
-      ...item,
-      token: item.token || encryptionService.encrypt(item.shortToken),
-      shortToken: hidePercentCharacters(item.shortToken),
-    }))
+    // The form re-submits existing tokens with a masked shortToken and
+    // no real `token` field — naively re-encrypting that masked string
+    // replaces the live PrivatBank token with garbage. Pull the current
+    // values from the DB so we can preserve `token` for entries that
+    // weren't actually edited.
+    const existing = await Domain.findById(domainId)
+      .select('domainBankToken')
+      .lean()
+    const existingTokens = (existing?.domainBankToken ?? []) as any[]
+
+    obj.domainBankToken = obj.domainBankToken
+      .map((item: any) => {
+        const looksLikeMaskedExisting =
+          !item.token &&
+          typeof item.shortToken === 'string' &&
+          item.shortToken.includes('*')
+
+        if (looksLikeMaskedExisting) {
+          const matched = existingTokens.find(
+            (e) => e?.shortToken === item.shortToken || e?.name === item.name
+          )
+          if (!matched?.token) {
+            // No way to recover the original token — drop the entry
+            // rather than persisting a bogus one.
+            return null
+          }
+          return { ...item, token: matched.token, shortToken: matched.shortToken }
+        }
+
+        return {
+          ...item,
+          token: item.token || encryptionService.encrypt(item.shortToken),
+          shortToken: hidePercentCharacters(item.shortToken),
+        }
+      })
+      .filter(Boolean)
 
     return obj
   }
@@ -116,7 +158,11 @@ export default async function handler(
             })
           }
 
-          const updatedObj = encryptDomainBankTokens(req.body, SECURE_TOKEN)
+          const updatedObj = await encryptDomainBankTokens(
+            req.body,
+            SECURE_TOKEN,
+            req.query.id as string
+          )
           if (
             !updatedObj.adminEmails ||
             !Array.isArray(updatedObj.adminEmails)
@@ -134,7 +180,11 @@ export default async function handler(
           )
           return res.status(200).json({ success: true, data: response })
         } else {
-          const updatedObj = encryptDomainBankTokens(req.body, SECURE_TOKEN)
+          const updatedObj = await encryptDomainBankTokens(
+            req.body,
+            SECURE_TOKEN,
+            req.query.id as string
+          )
           const response = await Domain.findOneAndUpdate(
             { _id: req.query.id },
             updatedObj,


### PR DESCRIPTION
Background: opening the domain edit modal, changing any field, and saving wiped `domainBankToken` for that domain — breaking the PrivatBank integration until someone re-pasted the token. Two layers of the same bug:

- Frontend submits `domainBankToken: formData.domainBankToken || []` even when the user never touched the Bank tab; if the form's value was '' (initialValues default) or [], the backend received an empty array and ran $set, zeroing out the field.
- Existing tokens come back from the server with `shortToken` masked (e.g. "abc***123") and no `token` field. The previous encrypt step unconditionally re-encrypted the masked string, replacing the live PrivatBank token with garbage on every save.

Backend fix in encryptDomainBankTokens:
- If `domainBankToken` is missing or empty, drop the field from the update payload entirely — Mongoose leaves the stored value alone.
- For entries that arrive without a `token` and a masked shortToken, read the current Domain.domainBankToken from the DB and reuse the stored token by matching on shortToken or name. If no match is found, drop that entry rather than persisting a bogus one.
- Genuinely new entries (real shortToken, no asterisks) still go through the same encrypt + hide-percent path as before.

Frontend belt-and-braces: wrap the per-token "×" button in a Popconfirm so a misclick can't yank the integration without an explicit "Так, видалити".