### PR TITLE
Added a button to refresh data without reloading pages

### DIFF
--- a/common/components/DashboardPage/blocks/payments.tsx
+++ b/common/components/DashboardPage/blocks/payments.tsx
@@ -148,6 +148,7 @@ const PaymentsBlock: React.FC<PaymentsBlockProps> = ({ sepDomainID }) => {
     isError: paymentsError,
     isLoading: paymentsLoading,
     isFetching: paymentsFetching,
+    refetch: refetchPayments,
   } = useGetAllPaymentsQuery(
     {
       skip: (currentPage - 1) * pageSize,
@@ -516,6 +517,8 @@ const PaymentsBlock: React.FC<PaymentsBlockProps> = ({ sepDomainID }) => {
       dispatch(setSelectedColumns(cols)),
     onBulkMarkPaid: handleBulkMarkPaid,
     onBulkDuplicate: handleBulkDuplicate,
+    onRefresh: () => refetchPayments(),
+    isRefreshing: paymentsFetching,
     domainFilter: filterProps.domainsFilter,
     realEstatesFilter: filterProps.companiesFilter,
     isDashboard: router.pathname === AppRoutes.INDEX,

--- a/common/components/Tables/Payment/Header.tsx
+++ b/common/components/Tables/Payment/Header.tsx
@@ -30,6 +30,8 @@ export interface PaymentsHeaderProps {
   onColumnsSelect: (columns: ServiceType[]) => void
   onBulkMarkPaid?: (payments: IExtendedPayment[]) => void
   onBulkDuplicate?: (payments: IExtendedPayment[]) => void
+  onRefresh?: () => void | Promise<unknown>
+  isRefreshing?: boolean
   onDeleteClick?: () => void
   domainFilter: IFilter[]
   realEstatesFilter: IFilter[]
@@ -53,6 +55,8 @@ const PaymentsHeader: React.FC<PaymentsHeaderProps> = ({
   onColumnsSelect,
   onBulkMarkPaid,
   onBulkDuplicate,
+  onRefresh,
+  isRefreshing,
   domainFilter,
   realEstatesFilter,
   isDashboard,
@@ -76,6 +80,8 @@ const PaymentsHeader: React.FC<PaymentsHeaderProps> = ({
       onColumnsSelect={onColumnsSelect}
       onBulkMarkPaid={onBulkMarkPaid}
       onBulkDuplicate={onBulkDuplicate}
+      onRefresh={onRefresh}
+      isRefreshing={isRefreshing}
       domainFilter={domainFilter}
       realEstatesFilter={realEstatesFilter}
       isDashboard={isDashboard}

--- a/common/components/UI/PaymentCardHeader/PaymentCardHeader.refresh.test.tsx
+++ b/common/components/UI/PaymentCardHeader/PaymentCardHeader.refresh.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { useRouter } from 'next/router'
+import { message } from 'antd'
+import { AppRoutes, Roles } from '@utils/constants'
+import PaymentCardHeader from '@components/UI/PaymentCardHeader'
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}))
+
+jest.mock('antd', () => {
+  const antd = jest.requireActual('antd')
+  return {
+    ...antd,
+    message: {
+      loading: jest.fn(),
+      success: jest.fn(),
+      error: jest.fn(),
+    },
+  }
+})
+
+jest.mock('@common/api/paymentApi/payment.api', () => ({
+  useDeleteMultiplePaymentsMutation: jest.fn(() => [jest.fn()]),
+  useHtmlToPdfZipMutation: jest.fn(() => [jest.fn()]),
+  useGenerateExcelMutation: jest.fn(() => [jest.fn()]),
+}))
+
+jest.mock('@common/api/userApi/user.api', () => ({
+  useGetCurrentUserQuery: jest.fn(),
+}))
+
+jest.mock('@common/api/customServicesApi/customServices.api', () => ({
+  useGetCustomServicesQuery: jest.fn(() => ({ data: { data: [] } })),
+}))
+
+jest.mock('@components/UI/PaymentCardHeader/PaymentCardLabel', () => {
+  const Mock = () => <div data-testid="payment-card-label" />
+  Mock.displayName = 'PaymentCardLabel'
+  return Mock
+})
+jest.mock('@components/AddPaymentModal', () => {
+  const Mock = () => null
+  Mock.displayName = 'AddPaymentModal'
+  return Mock
+})
+jest.mock('@components/UI/PaymentCardHeader/ImportInvoices', () => {
+  const Mock = () => null
+  Mock.displayName = 'ImportInvoices'
+  return Mock
+})
+jest.mock(
+  '@components/UI/PaymentCardHeader/ImportInvoices/ImportInvoicesModal',
+  () => {
+    const Mock = () => null
+    Mock.displayName = 'ImportInvoicesModal'
+    return Mock
+  }
+)
+jest.mock(
+  '@components/Forms/GroupedReceiptForm/HeadlessReceiptRenderer',
+  () => ({
+    __esModule: true,
+    default: () => null,
+  })
+)
+
+const messageMock = message as unknown as {
+  loading: jest.Mock
+  success: jest.Mock
+  error: jest.Mock
+}
+
+const {
+  useGetCurrentUserQuery,
+} = jest.requireMock('@common/api/userApi/user.api')
+
+const makeProps = (overrides: Record<string, any> = {}) => ({
+  setCurrentDateFilter: jest.fn(),
+  currentPayment: {},
+  paymentActions: { edit: false, preview: false },
+  closeEditModal: jest.fn(),
+  paymentsDeleteItems: [],
+  payments: { data: [], total: 0 },
+  streets: [],
+  filters: {},
+  setFilters: jest.fn(),
+  selectedPayments: [],
+  setPaymentsDeleteItems: jest.fn(),
+  setSelectedPayments: jest.fn(),
+  enablePaymentsButton: true,
+  onColumnsSelect: jest.fn(),
+  domainFilter: [],
+  realEstatesFilter: [],
+  onRefresh: jest.fn().mockResolvedValue(undefined),
+  isRefreshing: false,
+  ...overrides,
+})
+
+const setAdmin = (isAdmin: boolean) =>
+  (useGetCurrentUserQuery as jest.Mock).mockReturnValue({
+    data: { roles: isAdmin ? [Roles.GLOBAL_ADMIN] : [] },
+  })
+
+const openDropdown = () => fireEvent.click(screen.getByRole('button'))
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ;(useRouter as jest.Mock).mockReturnValue({
+    pathname: AppRoutes.PAYMENT,
+    push: jest.fn(),
+  })
+  setAdmin(true)
+})
+
+describe('PaymentCardHeader — кнопка "Оновити"', () => {
+  it('показує пункт "Оновити" для адміна', () => {
+    render(<PaymentCardHeader {...makeProps()} />)
+    openDropdown()
+
+    expect(screen.getByText('Оновити')).toBeInTheDocument()
+  })
+
+  it('не показує пункт "Оновити" для не-адміна (немає меню)', () => {
+    setAdmin(false)
+    render(<PaymentCardHeader {...makeProps()} />)
+
+    expect(screen.queryByText('Оновити')).not.toBeInTheDocument()
+  })
+
+  it('викликає onRefresh при кліку', () => {
+    const onRefresh = jest.fn().mockResolvedValue(undefined)
+    render(<PaymentCardHeader {...makeProps({ onRefresh })} />)
+    openDropdown()
+    fireEvent.click(screen.getByText('Оновити'))
+
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('не скидає фільтри, пошук та вибір при оновленні', () => {
+    const props = makeProps()
+    render(<PaymentCardHeader {...props} />)
+    openDropdown()
+    fireEvent.click(screen.getByText('Оновити'))
+
+    expect(props.setFilters).not.toHaveBeenCalled()
+    expect(props.setCurrentDateFilter).not.toHaveBeenCalled()
+    expect(props.setSelectedPayments).not.toHaveBeenCalled()
+    expect(props.setPaymentsDeleteItems).not.toHaveBeenCalled()
+  })
+
+  it('показує індикатор завантаження, а потім успіх', async () => {
+    render(<PaymentCardHeader {...makeProps()} />)
+    openDropdown()
+    fireEvent.click(screen.getByText('Оновити'))
+
+    expect(messageMock.loading).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'payments-refresh' })
+    )
+    await waitFor(() =>
+      expect(messageMock.success).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'payments-refresh' })
+      )
+    )
+    expect(messageMock.error).not.toHaveBeenCalled()
+  })
+
+  it('показує помилку, якщо оновлення впало', async () => {
+    const onRefresh = jest.fn().mockRejectedValue(new Error('network'))
+    render(<PaymentCardHeader {...makeProps({ onRefresh })} />)
+    openDropdown()
+    fireEvent.click(screen.getByText('Оновити'))
+
+    await waitFor(() =>
+      expect(messageMock.error).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'payments-refresh' })
+      )
+    )
+    expect(messageMock.success).not.toHaveBeenCalled()
+  })
+
+  it('крутить іконку, поки isRefreshing === true', () => {
+    render(<PaymentCardHeader {...makeProps({ isRefreshing: true })} />)
+    openDropdown()
+
+    expect(document.querySelector('.anticon-spin')).toBeTruthy()
+  })
+})

--- a/common/components/UI/PaymentCardHeader/index.tsx
+++ b/common/components/UI/PaymentCardHeader/index.tsx
@@ -12,6 +12,7 @@ import {
   MenuOutlined,
   ImportOutlined,
   MoreOutlined,
+  ReloadOutlined,
 } from '@ant-design/icons'
 import { dateToDefaultFormat } from '@assets/features/formatDate'
 import {
@@ -85,6 +86,8 @@ export interface PaymentCardHeaderProps {
   isDashboard?: boolean
   onBulkMarkPaid?: (payments: IExtendedPayment[]) => void
   onBulkDuplicate?: (payments: IExtendedPayment[]) => void
+  onRefresh?: () => void | Promise<unknown>
+  isRefreshing?: boolean
 }
 
 const PaymentCardHeader: React.FC<PaymentCardHeaderProps> = ({
@@ -110,6 +113,8 @@ const PaymentCardHeader: React.FC<PaymentCardHeaderProps> = ({
   onDeleteClick,
   onBulkMarkPaid,
   onBulkDuplicate,
+  onRefresh,
+  isRefreshing,
 }) => {
   const router = useRouter()
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -226,7 +231,20 @@ const PaymentCardHeader: React.FC<PaymentCardHeaderProps> = ({
     setBulkPaymentsToRender(selectedPayments as IExtendedPayment[])
   }
 
+  const handleRefresh = async () => {
+    if (!onRefresh) return
+    const key = 'payments-refresh'
+    message.loading({ content: 'Оновлення даних...', key })
+    try {
+      await onRefresh()
+      message.success({ content: 'Дані оновлено', key })
+    } catch {
+      message.error({ content: 'Не вдалося оновити дані', key })
+    }
+  }
+
   const menuActions: Record<string, () => void> = {
+    refresh: handleRefresh,
     export: handleExportExcel,
     import: () => setIsImportModalOpen(true),
     invoices: () => router.push(AppRoutes.PAYMENT_BULK),
@@ -334,6 +352,15 @@ const PaymentCardHeader: React.FC<PaymentCardHeaderProps> = ({
           },
         ]
       : []),
+    ...(isAdmin
+      ? [
+          {
+            key: 'refresh',
+            label: 'Оновити',
+            icon: <ReloadOutlined spin={isRefreshing} />,
+          },
+        ]
+      : []),
     ...(isAdmin && pathname === AppRoutes.PAYMENT && selectedPayments.length > 0
       ? [{ key: 'export', label: 'Export to Excel', icon: <ExportOutlined /> }]
       : []),
@@ -386,6 +413,11 @@ const PaymentCardHeader: React.FC<PaymentCardHeaderProps> = ({
   ]
 
   const dashboardItems: MenuProps['items'] = [
+    {
+      key: 'refresh',
+      label: 'Оновити',
+      icon: <ReloadOutlined spin={isRefreshing} />,
+    },
     { key: 'import', label: 'Імпорт', icon: <ImportOutlined /> },
     { key: 'invoices', label: 'Інвойси', icon: <SelectOutlined /> },
     { key: 'add', label: 'Додати', icon: <PlusOutlined /> },


### PR DESCRIPTION
https://app.asana.com/1/1202389091502512/project/1202389032764573/task/1215412913989663
<img width="354" height="331" alt="image" src="https://github.com/user-attachments/assets/05c34227-cff4-48b5-9d4a-1ce82af1b238" />
Додано кнопку «Оновити» у меню заголовка сторінки платежів. Дані списку завантажуються через RTK Query (useGetAllPaymentsQuery), а всі фільтри, пошук, сортування й пагінація зберігаються окремо в Redux тому при натисканні кнопки викликається refetch(), який повторно запитує дані з апі. Табл підтягує свіжі дані без перезавантаження сторінки.