### PR TITLE
Hotfix/chromium pack default (#1652)

### DIFF
--- a/common/modules/store/paymentsSlice.ts
+++ b/common/modules/store/paymentsSlice.ts
@@ -66,6 +66,7 @@ const paymentsSlice = createSlice({
       }
     },
     setFilters(state, action: PayloadAction<Record<string, any> | undefined>) {
+      state.currentPage = 1
       state.filters = action.payload
     },
     setDomainsFilter(state, action: PayloadAction<IFilter[]>) {

--- a/next.config.js
+++ b/next.config.js
@@ -11,18 +11,13 @@ const nextConfig = {
   reactStrictMode: true,
   i18n,
   experimental: {
+    // Chromium itself is fetched at runtime from a remote pack via
+    // @sparticuz/chromium-min (see utils/pdf/bufferGenerators.ts), so we only
+    // need to keep these out of the webpack bundle — no asset tracing required.
     serverComponentsExternalPackages: [
-      '@sparticuz/chromium',
       '@sparticuz/chromium-min',
       'puppeteer-core',
     ],
-    // Chromium's binary/library assets are loaded at runtime via fs, so Next's
-    // file tracing misses them and the serverless function ships without
-    // libnspr4.so etc. Force the @sparticuz/chromium assets into every API
-    // function so the bundled-binary path works on Vercel/Lambda.
-    outputFileTracingIncludes: {
-      '/api/**': ['./node_modules/@sparticuz/chromium/**'],
-    },
   },
   transpilePackages: [
     'antd',

--- a/utils/pdf/bufferGenerators.ts
+++ b/utils/pdf/bufferGenerators.ts
@@ -10,6 +10,16 @@ const COMMON_LAUNCH_ARGS = [
   '--disable-gpu',
 ]
 
+// On serverless (Vercel/AWS Lambda) a bundled Chromium can't load its shared
+// libraries (libnspr4.so etc.), so we always fetch the matching pack (binary +
+// libs) at runtime via @sparticuz/chromium-min. Defaults to the public v127
+// pack so it works even where we can't set env vars (AWS prod); override with
+// CHROMIUM_PACK_URL to point at your own mirror. Must match @sparticuz/chromium*
+// major (127) and puppeteer-core (22.x → Chrome 127).
+const CHROMIUM_PACK_URL =
+  process.env.CHROMIUM_PACK_URL ||
+  'https://github.com/Sparticuz/chromium/releases/download/v127.0.0/chromium-v127.0.0-pack.tar'
+
 let executablePathPromise: Promise<string> | undefined
 
 function resolveExecutablePath(
@@ -29,22 +39,15 @@ function resolveExecutablePath(
 
 async function launchBrowser() {
   if (isServerless) {
-    // When CHROMIUM_PACK_URL is set, fetch the Chromium binary + libs from that
-    // remote pack via @sparticuz/chromium-min (keeps the function small and
-    // sidesteps bundling issues). Otherwise use the full @sparticuz/chromium
-    // whose assets are force-traced into the function (see next.config.js).
-    const packUrl = process.env.CHROMIUM_PACK_URL
     const [{ default: puppeteerCore }, { default: chromium }] =
       await Promise.all([
         import('puppeteer-core'),
-        packUrl
-          ? import('@sparticuz/chromium-min')
-          : import('@sparticuz/chromium'),
+        import('@sparticuz/chromium-min'),
       ])
     return puppeteerCore.launch({
       args: [...chromium.args, ...COMMON_LAUNCH_ARGS],
       defaultViewport: chromium.defaultViewport,
-      executablePath: await resolveExecutablePath(chromium, packUrl),
+      executablePath: await resolveExecutablePath(chromium, CHROMIUM_PACK_URL),
       headless: true,
       protocolTimeout: 60_000,
     })


### PR DESCRIPTION
* FixPaginationFilterBug (#1480)

* fix debtors (#1537) (#1538)

* fix debtors (#1537)

* fix bulk delete for domain admin (#1539)

---------



* Merge pull request #1541 from VanyaRPP/updated-domain-modal (#1542)

modal-tabs



* Swap colums of domain and complanies. Changed the CompanisTable.test (#1639)

https://app.asana.com/1/1202389091502512/project/1215561077948096/task/1215650233785960

* fix(pdf): always fetch Chromium from remote pack on serverless (no env needed)

Variant A (bundling @sparticuz/chromium via outputFileTracingIncludes) is already on deploy and still fails on AWS prod with 'libnspr4.so: cannot open shared object file' - the shared libs don't load from the bundled binary, and we can't set env vars on the AWS deployment.

Now always use @sparticuz/chromium-min with a default remote pack URL, so Chromium + its libs are downloaded to /tmp at runtime. CHROMIUM_PACK_URL still overrides the default (e.g. a self-hosted mirror). Drop the now-moot outputFileTracingIncludes.



---------