### PR TITLE
Змінити логіку прив'язки послуг до компаній

### DIFF
--- a/common/components/UI/CustomServicesCard/CustomServicesCard.test.tsx
+++ b/common/components/UI/CustomServicesCard/CustomServicesCard.test.tsx
@@ -69,13 +69,13 @@ const renderWithForm = (ui: React.ReactElement) => {
 }
 
 describe('CustomServicesCard', () => {
-  const setFieldsValueMock = jest.fn()
+  const setFieldValueMock = jest.fn()
   const defaultMockUser = { data: { roles: [Roles.DOMAIN_ADMIN] } }
 
   beforeEach(() => {
     mockUseGetCurrentUserQuery.mockReturnValue(defaultMockUser)
     useWatchSpy.mockReturnValue([])
-    setFieldsValueMock.mockClear()
+    setFieldValueMock.mockClear()
   })
 
   afterEach(() => {
@@ -85,7 +85,7 @@ describe('CustomServicesCard', () => {
   test('renders add button when not disabled and not service form', () => {
     renderWithForm(
       <CustomServicesCard
-        form={{ setFieldsValue: setFieldsValueMock }}
+        form={{ setFieldValue: setFieldValueMock }}
         allCustomServices={ALL_CUSTOM_SERVICES}
         disabled={false}
         isServiceForm={false}
@@ -95,30 +95,26 @@ describe('CustomServicesCard', () => {
     expect(screen.getByText('Індивідуальні послуги')).toBeInTheDocument()
   })
 
-  // СЦЕНАРІЙ 1: Початковий стан — всі послуги вибрані зі значенням undefined
-  test('auto-populates all services with undefined price on init', () => {
+  test('auto-populates all services with null price on init', () => {
     renderWithForm(
       <CustomServicesCard
-        form={{ setFieldsValue: setFieldsValueMock }}
+        form={{ setFieldValue: setFieldValueMock }}
         allCustomServices={ALL_CUSTOM_SERVICES}
         disabled={false}
         skipAutoPopulate={false}
       />
     )
 
-    expect(setFieldsValueMock).toHaveBeenCalledWith({
-      customServices: [
-        {
-          _id: '1',
-          label: 'Послуга 1',
-          fieldName: 'service1',
-          price: undefined,
-        },
-      ],
-    })
+    expect(setFieldValueMock).toHaveBeenCalledWith('customServices', [
+      {
+        _id: '1',
+        label: 'Послуга 1',
+        fieldName: 'service1',
+        price: null,
+      },
+    ])
   })
 
-  // СЦЕНАРІЙ 2: Робота кнопки "Прибрати всі" (Скасувати вибір)
   test('clears all services when "Скасувати вибір" is clicked', () => {
     useWatchSpy.mockReturnValue([
       { _id: '1', label: 'Послуга 1', fieldName: 'service1', price: 100 },
@@ -126,7 +122,7 @@ describe('CustomServicesCard', () => {
 
     renderWithForm(
       <CustomServicesCard
-        form={{ setFieldsValue: setFieldsValueMock }}
+        form={{ setFieldValue: setFieldValueMock }}
         allCustomServices={ALL_CUSTOM_SERVICES}
         disabled={false}
       />
@@ -134,16 +130,13 @@ describe('CustomServicesCard', () => {
 
     fireEvent.click(screen.getByText('Скасувати вибір'))
 
-    expect(setFieldsValueMock).toHaveBeenCalledWith({
-      customServices: [],
-    })
+    expect(setFieldValueMock).toHaveBeenCalledWith('customServices', [])
   })
 
-  // СЦЕНАРІЙ 3: Вибір окремих послуг (перевірка undefined замість 0)
-  test('adds custom service from dropdown with undefined price', () => {
+  test('adds custom service from dropdown with null price', () => {
     renderWithForm(
       <CustomServicesCard
-        form={{ setFieldsValue: setFieldsValueMock }}
+        form={{ setFieldValue: setFieldValueMock }}
         allCustomServices={ALL_CUSTOM_SERVICES}
         disabled={false}
         isServiceForm={false}
@@ -152,15 +145,13 @@ describe('CustomServicesCard', () => {
 
     fireEvent.click(screen.getByText('Послуга 1'))
 
-    expect(setFieldsValueMock).toHaveBeenCalledWith({
-      customServices: [
-        {
-          _id: '1',
-          label: 'Послуга 1',
-          fieldName: 'service1',
-          price: undefined,
-        },
-      ],
-    })
+    expect(setFieldValueMock).toHaveBeenCalledWith('customServices', [
+      {
+        _id: '1',
+        label: 'Послуга 1',
+        fieldName: 'service1',
+        price: null,
+      },
+    ])
   })
 })

--- a/common/components/UI/CustomServicesCard/CustomServicesCard.test.tsx
+++ b/common/components/UI/CustomServicesCard/CustomServicesCard.test.tsx
@@ -17,8 +17,6 @@ jest.mock('@utils/helpers', () => ({
   ),
 }))
 
-// antd Select's virtualised popup doesn't open in jsdom; stub it with a flat
-// list of buttons so we can drive onChange via real clicks.
 jest.mock('antd', () => {
   const actual = jest.requireActual('antd')
   const React = require('react')
@@ -27,6 +25,7 @@ jest.mock('antd', () => {
     value = [],
     onChange,
     placeholder,
+    popupRender,
   }: any) =>
     React.createElement(
       'div',
@@ -37,6 +36,7 @@ jest.mock('antd', () => {
           { 'data-testid': 'placeholder' },
           placeholder
         ),
+      popupRender && popupRender(null),
       options.map((o: any) =>
         React.createElement(
           'button',
@@ -95,7 +95,52 @@ describe('CustomServicesCard', () => {
     expect(screen.getByText('Індивідуальні послуги')).toBeInTheDocument()
   })
 
-  test('adds custom service from dropdown', () => {
+  // СЦЕНАРІЙ 1: Початковий стан — всі послуги вибрані зі значенням undefined
+  test('auto-populates all services with undefined price on init', () => {
+    renderWithForm(
+      <CustomServicesCard
+        form={{ setFieldsValue: setFieldsValueMock }}
+        allCustomServices={ALL_CUSTOM_SERVICES}
+        disabled={false}
+        skipAutoPopulate={false}
+      />
+    )
+
+    expect(setFieldsValueMock).toHaveBeenCalledWith({
+      customServices: [
+        {
+          _id: '1',
+          label: 'Послуга 1',
+          fieldName: 'service1',
+          price: undefined,
+        },
+      ],
+    })
+  })
+
+  // СЦЕНАРІЙ 2: Робота кнопки "Прибрати всі" (Скасувати вибір)
+  test('clears all services when "Скасувати вибір" is clicked', () => {
+    useWatchSpy.mockReturnValue([
+      { _id: '1', label: 'Послуга 1', fieldName: 'service1', price: 100 },
+    ])
+
+    renderWithForm(
+      <CustomServicesCard
+        form={{ setFieldsValue: setFieldsValueMock }}
+        allCustomServices={ALL_CUSTOM_SERVICES}
+        disabled={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Скасувати вибір'))
+
+    expect(setFieldsValueMock).toHaveBeenCalledWith({
+      customServices: [],
+    })
+  })
+
+  // СЦЕНАРІЙ 3: Вибір окремих послуг (перевірка undefined замість 0)
+  test('adds custom service from dropdown with undefined price', () => {
     renderWithForm(
       <CustomServicesCard
         form={{ setFieldsValue: setFieldsValueMock }}
@@ -105,7 +150,6 @@ describe('CustomServicesCard', () => {
       />
     )
 
-    fireEvent.click(screen.getByText('Індивідуальні послуги'))
     fireEvent.click(screen.getByText('Послуга 1'))
 
     expect(setFieldsValueMock).toHaveBeenCalledWith({
@@ -114,7 +158,7 @@ describe('CustomServicesCard', () => {
           _id: '1',
           label: 'Послуга 1',
           fieldName: 'service1',
-          price: 0,
+          price: undefined,
         },
       ],
     })

--- a/common/components/UI/CustomServicesCard/index.tsx
+++ b/common/components/UI/CustomServicesCard/index.tsx
@@ -32,7 +32,7 @@ const CustomServicesCard: FC<CustomServicesCardProps> = ({
     _id: service?._id,
     label: service?.label,
     fieldName: service?.fieldName,
-    price: 0,
+    price: undefined,
   })
 
   const applyIds = (ids: string[]) => {

--- a/common/components/UI/CustomServicesCard/index.tsx
+++ b/common/components/UI/CustomServicesCard/index.tsx
@@ -32,7 +32,7 @@ const CustomServicesCard: FC<CustomServicesCardProps> = ({
     _id: service?._id,
     label: service?.label,
     fieldName: service?.fieldName,
-    price: undefined,
+    price: null,
   })
 
   const applyIds = (ids: string[]) => {
@@ -43,7 +43,7 @@ const CustomServicesCard: FC<CustomServicesCardProps> = ({
       const source = allCustomServices.find((s) => s?._id === id)
       return buildEntry(source)
     })
-    form.setFieldsValue({ customServices: next })
+    form.setFieldValue('customServices', next)
   }
 
   const handleSelectChange = (ids: string[]) => {
@@ -95,7 +95,7 @@ const CustomServicesCard: FC<CustomServicesCardProps> = ({
   const handleRemoveService = (index: number) => {
     const updated = [...customServices]
     updated.splice(index, 1)
-    form.setFieldsValue({ customServices: updated })
+    form.setFieldValue('customServices', updated)
   }
   const dashIfEmpty = (v: any) => (v === 0 || v ? v : '-')
 
@@ -111,9 +111,7 @@ const CustomServicesCard: FC<CustomServicesCardProps> = ({
       return
     }
 
-    form.setFieldsValue({
-      customServices: allCustomServices.map(buildEntry),
-    })
+    form.setFieldValue('customServices', allCustomServices.map(buildEntry))
     autoPopulatedRef.current = true
   }, [
     allCustomServices,

--- a/common/components/UI/RealEstateComponents/RealEstateModal/RealEstateForm/RealEstateForm.test.tsx
+++ b/common/components/UI/RealEstateComponents/RealEstateModal/RealEstateForm/RealEstateForm.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { Form, FormInstance } from 'antd'
 import RealEstateForm from './index'
 
@@ -67,5 +67,18 @@ describe('RealEstateForm — префіл адреси', () => {
     expect(addressesSpy).toHaveBeenCalledWith(
       expect.objectContaining({ street: undefined })
     )
+  })
+})
+
+describe('RealEstateForm — вкладки (Tabs)', () => {
+  it('відображає вкладку "Послуги" та рендерить CustomServicesCard при перемиканні', () => {
+    render(<Wrapper />)
+
+    const servicesTab = screen.getByText('Послуги')
+    expect(servicesTab).toBeInTheDocument()
+
+    fireEvent.click(servicesTab)
+
+    expect(screen.getByTestId('custom-services')).toBeInTheDocument()
   })
 })

--- a/common/components/UI/RealEstateComponents/RealEstateModal/RealEstateForm/index.tsx
+++ b/common/components/UI/RealEstateComponents/RealEstateModal/RealEstateForm/index.tsx
@@ -3,18 +3,17 @@ import { validateField } from '@assets/features/validators'
 import { IExtendedRealestate } from '@common/api/realestateApi/realestate.api.types'
 import EmailSelect from '@components/UI/Reusable/EmailSelect'
 import {
-  Button,
-  Card,
   Checkbox,
-  Flex,
   Form,
   FormInstance,
   Input,
   InputNumber,
   Select,
+  Tabs,
   Typography,
 } from 'antd'
-import { FC, useEffect } from 'react'
+import type { TabsProps } from 'antd'
+import { FC, useEffect, useState } from 'react'
 import AddressesSelect from '../../../Reusable/AddressesSelect'
 import DomainsSelect from '../../../Reusable/DomainsSelect'
 import s from './style.module.scss'
@@ -23,7 +22,6 @@ import { IDomain } from '@modules/models/Domain'
 import { inputNumberParser } from '@utils/helpers'
 import { CURRENCY_SELECT_OPTIONS, Currency } from '@utils/constants'
 import { useGetAllServicesQuery } from '@common/api/serviceApi/service.api'
-import DomainsServices from '@components/UI/DomainsComponents/DomainModal/DomainForm/DomainsServices'
 import CustomServicesCard from '../../../CustomServicesCard'
 
 interface Props {
@@ -46,11 +44,7 @@ const RealEstateForm: FC<Props> = ({
   const watchedDomainId = Form.useWatch('domain', form)
   const domainId = watchedDomainId || currentRealEstate?.domain?._id
   const streetId = currentRealEstate?.street?._id
-  const {
-    data: domain = {} as IDomain,
-    isLoading: isDomainLoading,
-    isError: isDomainError,
-  } = useGetDomainByPkQuery(
+  const { data: domain = {} as IDomain } = useGetDomainByPkQuery(
     { domainId: domainId || currentRealEstate?.domain?._id },
     { skip: !domainId && !currentRealEstate?.domain?._id }
   )
@@ -97,7 +91,6 @@ const RealEstateForm: FC<Props> = ({
 
   const isServiceExistById = (serviceId: string) => {
     if (!domain?.customServices?.length) return false
-
     return domain.customServices.some((group) =>
       group.services?.includes(serviceId)
     )
@@ -108,16 +101,6 @@ const RealEstateForm: FC<Props> = ({
     const existedValues = services.map((x) => !!x[value])
     return existedValues.includes(true)
   }
-
-  const latestGarbageService = [...(services ?? [])]
-    .filter(
-      (s) =>
-        s.garbageCollectorPrice &&
-        s.garbageCollectorPrice > 0 &&
-        String(s.domain?._id) === String(domainId) &&
-        String(s.street?._id) === String(streetId)
-    )
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())[0]
 
   const isMeterBasedServiceExist =
     isServiceExistById('677d414283b6ef93c6b8ea2c') ||
@@ -132,18 +115,8 @@ const RealEstateForm: FC<Props> = ({
     return val && /^[0-9a-fA-F]{24}$/.test(String(val)) ? val : undefined
   }
 
-  return (
-    <Form
-      form={form}
-      requiredMark={editable}
-      layout="vertical"
-      className={s.Form}
-      onValuesChange={() => setIsValueChanged(true)}
-      initialValues={{
-        currency: currentRealEstate?.currency || Currency.UAH,
-        street: getSafeStreetId(),
-      }}
-    >
+  const renderMainInfo = () => (
+    <>
       <DomainsSelect form={form} edit={!!currentRealEstate} />
       <Form.Item
         name="street"
@@ -234,14 +207,6 @@ const RealEstateForm: FC<Props> = ({
           </Form.Item>
         </>
       )}
-      <Form.Item label="Індивідуальні послуги">
-        <CustomServicesCard
-          form={form}
-          disabled={!editable}
-          allCustomServices={customServices}
-          skipAutoPopulate
-        />
-      </Form.Item>
 
       {isServiceExist('inflicionPrice') && (
         <Form.Item
@@ -252,6 +217,54 @@ const RealEstateForm: FC<Props> = ({
           <Checkbox disabled={!editable} />
         </Form.Item>
       )}
+    </>
+  )
+
+  const renderServices = () => (
+    <>
+      <div style={{ marginBottom: 16 }}>
+        <Typography.Text type="secondary">
+          Оберіть послуги, які будуть доступні для цієї компанії, та вкажіть
+          їхню вартість.
+        </Typography.Text>
+      </div>
+      <Form.Item style={{ marginBottom: 0 }}>
+        <CustomServicesCard
+          form={form}
+          disabled={!editable}
+          allCustomServices={customServices}
+          skipAutoPopulate={!!currentRealEstate}
+        />
+      </Form.Item>
+    </>
+  )
+
+  const tabItems: TabsProps['items'] = [
+    {
+      key: '1',
+      label: 'Основна інформація',
+      children: renderMainInfo(),
+    },
+    {
+      key: '2',
+      label: 'Послуги',
+      children: renderServices(),
+    },
+  ]
+
+  return (
+    <Form
+      form={form}
+      requiredMark={editable}
+      layout="vertical"
+      className={s.Form}
+      onValuesChange={() => setIsValueChanged(true)}
+      initialValues={{
+        currency: currentRealEstate?.currency || Currency.UAH,
+        street: getSafeStreetId(),
+      }}
+    >
+      <Tabs defaultActiveKey="1" items={tabItems} />
     </Form>
   )
 }

--- a/common/components/UI/RealEstateComponents/RealEstateModal/RealEstateForm/index.tsx
+++ b/common/components/UI/RealEstateComponents/RealEstateModal/RealEstateForm/index.tsx
@@ -60,10 +60,7 @@ const RealEstateForm: FC<Props> = ({
         ...service,
         enabled: true,
       }))
-
-      form.setFieldsValue({
-        services: servicesWithEnabled,
-      })
+      form.setFieldValue('services', servicesWithEnabled)
     }
   }, [services, currentRealEstate, form])
 
@@ -82,9 +79,7 @@ const RealEstateForm: FC<Props> = ({
       }
 
       setTimeout(() => {
-        form.setFieldsValue({
-          street: streetVal,
-        })
+        form.setFieldValue('street', streetVal)
       }, 0)
     }
   }, [domainId, currentRealEstate, form])

--- a/common/components/UI/RealEstateComponents/RealEstateModal/index.tsx
+++ b/common/components/UI/RealEstateComponents/RealEstateModal/index.tsx
@@ -57,7 +57,7 @@ const RealEstateModal: FC<Props> = ({
               _id: s._id,
               label: s.name,
               fieldName: s.fieldName,
-              price: 0,
+              price: undefined,
             }))
           : []
       ) || []
@@ -66,13 +66,9 @@ const RealEstateModal: FC<Props> = ({
 
   const mergedCustomServices = useMemo(() => {
     const saved = currentRealEstate?.customServices || []
-    const validSaved = saved.filter((s) =>
+    return saved.filter((s) =>
       domainCustomServices.some((d) => d._id === s._id)
     )
-    const newFromDomain = domainCustomServices.filter(
-      (d) => !validSaved.some((s) => s._id === d._id)
-    )
-    return [...validSaved, ...newFromDomain]
   }, [currentRealEstate, domainCustomServices])
 
   useEffect(() => {
@@ -102,7 +98,7 @@ const RealEstateModal: FC<Props> = ({
       discount: currentRealEstate?.discount || 0,
       cleaning: currentRealEstate?.cleaning || 0,
       services: currentRealEstate?.services || [],
-      customServices: mergedCustomServices,
+      customServices: currentRealEstate ? mergedCustomServices : [],
     })
 
     initializedRef.current = true


### PR DESCRIPTION
https://app.asana.com/1/1202389091502512/project/1214169728867936/task/1216072903305491?focus=true

До
<img width="543" height="952" alt="image" src="https://github.com/user-attachments/assets/586628cb-86fb-4bf0-989b-ff407d50d356" />
<img width="534" height="954" alt="image" src="https://github.com/user-attachments/assets/f3ed992f-3899-4e49-b968-13b6bcfa6ec8" />

Після
<img width="702" height="879" alt="image" src="https://github.com/user-attachments/assets/f24a73f3-272a-40bb-a4e7-0e76aec59999" />
<img width="704" height="860" alt="image" src="https://github.com/user-attachments/assets/89713e78-32b2-4159-abb9-c6f79ccb7eda" />
<img width="684" height="858" alt="image" src="https://github.com/user-attachments/assets/e8b8d0ab-6d3a-4f1b-813a-4ac6eb39e188" />
<img width="668" height="510" alt="image" src="https://github.com/user-attachments/assets/c0ecd0c0-7d38-4cf0-9f5f-52b945795380" />

Покриття тестами:

1. Тести для форми компанії (RealEstateForm.test.tsx):

Нова структура: Перевірка, що модальне вікно тепер дійсно має вкладку «Послуги».
Перемикання: Перевірка, що при кліку на цю вкладку користувачу коректно відображається блок керування послугами.

2. Тести для списку послуг (CustomServicesCard.test.tsx):

Початковий стан: Перевірка, що при створенні нової компанії всі доступні послуги домену додаються до списку автоматично, але їхня вартість залишається порожньою (undefined, а не жорсткий 0).
Швидке очищення: Написаний сценарій, який перевіряє роботу кнопки «Скасувати вибір» (Прибрати всі). Тест підтверджує, що клік по ній миттєво очищає весь список послуг.
Ручний вибір: Перевірка, що коли користувач вибирає окрему послугу з випадаючого списку вручну, вона також додається зі значенням undefined, щоб не було випадкових нарахувань по 0 грн.