### PR TITLE
Add inline provider/company creation with tour

### DIFF
--- a/common/components/AddPaymentModal/InvoiceTour/index.tsx
+++ b/common/components/AddPaymentModal/InvoiceTour/index.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react'
+import { Tour, TourProps } from 'antd'
+import { useSession } from 'next-auth/react'
+
+interface InvoiceTourProps {
+  // Increment to manually (re)start the tour, e.g. from a "?" button.
+  startSignal?: number
+  onClose?: () => void
+}
+
+type CustomTourStep = TourProps['steps'][0] & {
+  nextButtonProps?: { children: string }
+  prevButtonProps?: { children: string }
+}
+
+// Highlights each field of the create-invoice form so a new user understands
+// what every input is for and how to add a service. Mirrors the DashboardTour
+// pattern (AntD Tour + per-user localStorage gate + querySelector targeting).
+const InvoiceTour: React.FC<InvoiceTourProps> = ({
+  startSignal = 0,
+  onClose,
+}) => {
+  const { data: session } = useSession()
+  const [tourVisible, setTourVisible] = useState(false)
+  const [currentStep, setCurrentStep] = useState(0)
+  const storageKey = `invoiceTourSeen_${session?.user?.email}`
+
+  useEffect(() => {
+    if (!session?.user?.email) return
+    const hasSeenTour = localStorage.getItem(storageKey)
+    if (!hasSeenTour) {
+      // Let the modal finish mounting so the targets exist.
+      const timer = setTimeout(() => {
+        setTourVisible(true)
+        localStorage.setItem(storageKey, 'true')
+      }, 600)
+      return () => clearTimeout(timer)
+    }
+  }, [session?.user?.email, storageKey])
+
+  useEffect(() => {
+    if (startSignal > 0) {
+      setTourVisible(true)
+      setCurrentStep(0)
+    }
+  }, [startSignal])
+
+  const handleClose = () => {
+    setTourVisible(false)
+    onClose?.()
+  }
+
+  const getEl = (key: string): HTMLElement =>
+    (document.querySelector(`[data-invoice-tour="${key}"]`) as HTMLElement) ||
+    document.body
+
+  const steps: CustomTourStep[] = [
+    {
+      title: 'Надавач послуг',
+      description:
+        'Хто виставляє рахунок — ваша організація/ОСББ. Оберіть наявного або створіть нового прямо тут.',
+      target: () => getEl('domain'),
+    },
+    {
+      title: 'Компанія (отримувач)',
+      description:
+        'Кому виставляється рахунок. Для нової компанії впишіть назву і пошту — вона з’явиться в рахунку як отримувач.',
+      target: () => getEl('company'),
+    },
+    {
+      title: 'Адреса та місяць',
+      description:
+        'Адреса — об’єкт, за яким нараховується оплата (необов’язково). Місяць — розрахунковий період рахунку.',
+      target: () => getEl('month'),
+    },
+    {
+      title: 'Тип оплати',
+      description:
+        'Дебет (Реалізація) — нарахування переліком послуг; Кредит (Оплата) — разова сума одним рядком.',
+      target: () => getEl('operation'),
+    },
+    {
+      title: 'Послуги та сума',
+      description:
+        'Додайте послуги: оберіть з каталогу домену або «Власне», вкажіть назву, кількість і ціну — сума порахується автоматично (ціна × кількість).',
+      target: () => getEl('amount'),
+    },
+    {
+      title: 'Номер, валюта і дата',
+      description:
+        'Номер інвойса підставляється автоматично (можна змінити). Поруч — валюта й дата виставлення.',
+      target: () => getEl('invoice-meta'),
+    },
+    {
+      title: 'Готово',
+      description: 'Натисніть «Додати», щоб зберегти рахунок.',
+      target: () =>
+        (document.querySelector('.ant-modal-footer') as HTMLElement) ||
+        getEl('amount'),
+    },
+  ].map((step, index, arr) => ({
+    ...step,
+    nextButtonProps: {
+      children: index === arr.length - 1 ? 'Зрозуміло' : 'Далі',
+    },
+    prevButtonProps: { children: 'Назад' },
+  }))
+
+  if (!tourVisible) {
+    return null
+  }
+
+  return (
+    <Tour
+      open={tourVisible}
+      onClose={handleClose}
+      onFinish={handleClose}
+      steps={steps}
+      current={currentStep}
+      onChange={setCurrentStep}
+      zIndex={1100}
+      mask={{ color: 'rgba(0, 0, 0, 0.45)' }}
+      type="primary"
+    />
+  )
+}
+
+export default InvoiceTour

--- a/common/components/AddPaymentModal/index.tsx
+++ b/common/components/AddPaymentModal/index.tsx
@@ -1,6 +1,11 @@
 import { useGetCustomServicesByDomainQuery } from '@common/api/customServicesApi/customServices.api'
 import { useCreateCustomServiceMutation } from '@common/api/customServicesApi/customServices.api'
-import { useGetDomainByPkQuery } from '@common/api/domainApi/domain.api'
+import {
+  useAddDomainMutation,
+  useGetDomainByPkQuery,
+} from '@common/api/domainApi/domain.api'
+import { useAddRealEstateMutation } from '@common/api/realestateApi/realestate.api'
+import { getNewEntityName, isNewEntityValue } from '@utils/inlineCreate'
 import { buildPaymentPayload } from './buildPaymentPayload'
 import { keepInvoiceRow } from './invoiceRowFilter'
 import { resolveTemplate, TemplateKey } from './resolveTemplate'
@@ -29,7 +34,9 @@ import {
   getPaymentProviderAndReciever,
   normalizeCurrency,
 } from '@utils/helpers'
-import { Form, Tabs, TabsProps, message } from 'antd'
+import { Button, Form, Tabs, TabsProps, message } from 'antd'
+import { QuestionCircleOutlined } from '@ant-design/icons'
+import InvoiceTour from './InvoiceTour'
 import { FormInstance } from 'antd/es/form/Form'
 import { useChangelogOptions } from './changelog/useChangelogOptions'
 import dayjs from 'dayjs'
@@ -121,6 +128,8 @@ const AddPaymentModal: FC<Props> = ({
   const lastLoadedCompanyId = useRef<string | null>(null)
   const [changed, setChanged] = useState(false)
   const [saved, setSaved] = useState(false)
+  // Bumping this re-opens the guided invoice tour from the "?" button.
+  const [tourSignal, setTourSignal] = useState(0)
   const [currPayment, setCurrPayment] = useState<IExtendedPayment>()
   const companyDefaultTemplate =
     typeof paymentData?.company === 'object'
@@ -179,7 +188,12 @@ const AddPaymentModal: FC<Props> = ({
   const activeDomainId = String(domainId || paymentDomainId || '')
   const { data: fetchedDomain } = useGetDomainByPkQuery(
     { domainId: activeDomainId },
-    { skip: !activeDomainId || typeof paymentData?.domain === 'object' }
+    {
+      skip:
+        !activeDomainId ||
+        isNewEntityValue(activeDomainId) ||
+        typeof paymentData?.domain === 'object',
+    }
   )
 
   useEffect(() => {
@@ -223,10 +237,45 @@ const AddPaymentModal: FC<Props> = ({
   // `usePaymentFormData` currently returns paymentData unchanged as `payment`,
   // so we destructure only the actual derived fields and use `paymentData`
   // directly everywhere a saved payment is needed.
-  const { company, service, prevService, prevPayment } = usePaymentFormData(
-    form,
-    paymentData
-  )
+  const {
+    company: fetchedCompany,
+    service,
+    prevService,
+    prevPayment,
+  } = usePaymentFormData(form, paymentData)
+
+  // The provider/company fields may hold a `new::<name>` sentinel for an entity
+  // the user is creating inline. Until it's materialized on submit there is
+  // nothing to fetch, so synthesize the company (and its provider/receiver
+  // block) from the typed values — this drives the live preview and the payload.
+  const companyValue = Form.useWatch('company', form)
+  const companyEmail = Form.useWatch('companyEmail', form)
+  const isNewCompany = isNewEntityValue(companyValue)
+  const isNewDomain = isNewEntityValue(domainId)
+
+  const company = useMemo(() => {
+    if (!isNewCompany) return fetchedCompany
+    const companyName = getNewEntityName(companyValue)
+    return {
+      companyName,
+      adminEmails: companyEmail ? [companyEmail] : [],
+      // Mirror materializeQuickEntities: a quick-created entity's description
+      // defaults to its name, so the live preview matches what gets saved.
+      description: companyName,
+      domain: isNewDomain
+        ? { description: getNewEntityName(domainId) }
+        : fetchedDomain,
+    } as unknown as IRealestate
+  }, [
+    isNewCompany,
+    fetchedCompany,
+    companyValue,
+    companyEmail,
+    isNewDomain,
+    domainId,
+    fetchedDomain,
+  ])
+
   const { provider, reciever } = getPaymentProviderAndReciever(company)
 
   const transaction = {
@@ -251,11 +300,13 @@ const AddPaymentModal: FC<Props> = ({
   const [editPayment, { isLoading: isEditingLoading }] =
     useEditPaymentMutation()
   const [createCustomService] = useCreateCustomServiceMutation()
+  const [addDomain] = useAddDomainMutation()
+  const [addRealEstate] = useAddRealEstateMutation()
 
   const resolveMonthServiceId = useResolveMonthServiceId()
   const { data: customDomainServices } = useGetCustomServicesByDomainQuery(
     { domainId },
-    { skip: !domainId }
+    { skip: !domainId || isNewEntityValue(domainId) }
   )
 
   const filteredInvoices = useMemo(() => {
@@ -472,11 +523,17 @@ const AddPaymentModal: FC<Props> = ({
       return
     }
 
-    const monthServiceId = await prepareMonthService(values)
-    if (monthServiceId === null) {
-      setSaved(false)
-      setChanged(true)
-      return
+    // A brand-new provider isn't created until final submit, so its month
+    // service can't be resolved yet — keep the placeholder for the preview and
+    // let handleSubmit materialize the provider and resolve it for real.
+    let monthServiceId = values.monthService
+    if (!isNewEntityValue(values.domain)) {
+      monthServiceId = await prepareMonthService(values)
+      if (monthServiceId === null) {
+        setSaved(false)
+        setChanged(true)
+        return
+      }
     }
 
     setCurrPayment({
@@ -488,8 +545,59 @@ const AddPaymentModal: FC<Props> = ({
     setActiveTabKey('2')
   }
 
+  // Materialize any inline-created provider/company (held as `new::` sentinels)
+  // into real records before building the payment. Order matters: creating the
+  // domain promotes the user to its admin (server adds them to adminEmails), so
+  // the company create that follows is authorized.
+  const materializeQuickEntities = useCallback(
+    async (formData: any): Promise<{ domain: string; company: string }> => {
+      let nextDomainId = formData.domain
+      let nextCompanyId = formData.company
+
+      if (isNewEntityValue(nextDomainId)) {
+        const name = getNewEntityName(nextDomainId).trim()
+        const created = await addDomain({
+          name,
+          // `description` is required; seed it with the name so a quick-created
+          // provider is valid without an extra field (the DomainModal builds a
+          // richer description from IBAN/МФО/РНОКПП later, if edited).
+          description: name,
+          streets: [],
+        } as any).unwrap()
+        nextDomainId = created.data._id
+        form.setFieldValue('domain', nextDomainId)
+      }
+
+      if (isNewEntityValue(nextCompanyId)) {
+        const companyName = getNewEntityName(nextCompanyId).trim()
+        const created = await addRealEstate({
+          companyName,
+          description: companyName,
+          domain: nextDomainId,
+          adminEmails: formData.companyEmail ? [formData.companyEmail] : [],
+        } as any).unwrap()
+        nextCompanyId = created.data._id
+        form.setFieldValue('company', nextCompanyId)
+      }
+
+      return { domain: nextDomainId, company: nextCompanyId }
+    },
+    [addDomain, addRealEstate, form]
+  )
+
   const handleSubmit = async () => {
     const formData = await form.validateFields()
+
+    let materialized: { domain: string; company: string }
+    try {
+      materialized = await materializeQuickEntities(formData)
+    } catch (e) {
+      console.error('quick-create failed', e)
+      message.error('Не вдалося створити надавача послуг або компанію')
+      return
+    }
+    formData.domain = materialized.domain
+    formData.company = materialized.company
 
     const monthServiceId = await prepareMonthService(formData)
     if (monthServiceId === null) return
@@ -516,7 +624,9 @@ const AddPaymentModal: FC<Props> = ({
       : await addPayment(finalPayload)
 
     if ('data' in response) {
-      const currentDomainId = String(domainId || paymentDomainId || '')
+      const currentDomainId = String(
+        formData.domain || domainId || paymentDomainId || ''
+      )
       if (currentDomainId && formData.invoice?.length) {
         await saveAdHocCustomServices(formData.invoice, currentDomainId)
       }
@@ -586,7 +696,25 @@ const AddPaymentModal: FC<Props> = ({
       }}
     >
       <Modal
-        title={edit ? 'Редагування рахунку' : !preview && 'Додавання рахунку'}
+        title={
+          edit ? (
+            'Редагування рахунку'
+          ) : !preview ? (
+            <span>
+              Додавання рахунку{' '}
+              <Button
+                type="text"
+                size="small"
+                icon={<QuestionCircleOutlined />}
+                onClick={() => setTourSignal((n) => n + 1)}
+                aria-label="Показати підказку"
+                title="Як заповнити рахунок"
+              />
+            </span>
+          ) : (
+            false
+          )
+        }
         onOk={activeTabKey === '1' ? handleOk : handleSubmit}
         okButtonProps={
           preview ? { style: { display: 'none' } } : edit ? {} : null
@@ -617,7 +745,7 @@ const AddPaymentModal: FC<Props> = ({
             generalSum: paymentData?.generalSum,
             currency: paymentData?.currency
               ? normalizeCurrency(paymentData.currency)
-              : undefined,
+              : Currency.UAH,
             invoiceNumber: paymentData?.invoiceNumber,
             invoiceCreationDate: dayjs(paymentData?.invoiceCreationDate),
             operation: paymentData?.type || Operations.Debit,
@@ -633,6 +761,7 @@ const AddPaymentModal: FC<Props> = ({
             onChange={setActiveTabKey}
           />
         </Form>
+        {!edit && !preview && <InvoiceTour startSignal={tourSignal} />}
       </Modal>
     </PaymentContext.Provider>
   )

--- a/common/components/AddPaymentModal/index.tsx
+++ b/common/components/AddPaymentModal/index.tsx
@@ -3,9 +3,11 @@ import { useCreateCustomServiceMutation } from '@common/api/customServicesApi/cu
 import {
   useAddDomainMutation,
   useGetDomainByPkQuery,
+  useGetDomainTypeTemplatesQuery,
 } from '@common/api/domainApi/domain.api'
 import { useAddRealEstateMutation } from '@common/api/realestateApi/realestate.api'
 import { getNewEntityName, isNewEntityValue } from '@utils/inlineCreate'
+import { domainTypeTemplateToCustomServices } from '@utils/domain/domain-type-template-services'
 import { buildPaymentPayload } from './buildPaymentPayload'
 import { keepInvoiceRow } from './invoiceRowFilter'
 import { resolveTemplate, TemplateKey } from './resolveTemplate'
@@ -302,6 +304,10 @@ const AddPaymentModal: FC<Props> = ({
   const [createCustomService] = useCreateCustomServiceMutation()
   const [addDomain] = useAddDomainMutation()
   const [addRealEstate] = useAddRealEstateMutation()
+  const { data: typeTemplates = [] } = useGetDomainTypeTemplatesQuery(
+    undefined,
+    { skip: edit || preview }
+  )
 
   const resolveMonthServiceId = useResolveMonthServiceId()
   const { data: customDomainServices } = useGetCustomServicesByDomainQuery(
@@ -556,6 +562,12 @@ const AddPaymentModal: FC<Props> = ({
 
       if (isNewEntityValue(nextDomainId)) {
         const name = getNewEntityName(nextDomainId).trim()
+        // Seed the provider's services from the chosen service-type template
+        // (e.g. «Комунальні»); empty when the user picked «Без послуг».
+        const templateId = formData.newDomainTemplateId || undefined
+        const template = templateId
+          ? typeTemplates.find((t) => t._id === templateId)
+          : undefined
         const created = await addDomain({
           name,
           // `description` is required; seed it with the name so a quick-created
@@ -563,6 +575,8 @@ const AddPaymentModal: FC<Props> = ({
           // richer description from IBAN/МФО/РНОКПП later, if edited).
           description: name,
           streets: [],
+          domainTypeTemplateId: templateId,
+          customServices: domainTypeTemplateToCustomServices(template),
         } as any).unwrap()
         nextDomainId = created.data._id
         form.setFieldValue('domain', nextDomainId)
@@ -582,7 +596,7 @@ const AddPaymentModal: FC<Props> = ({
 
       return { domain: nextDomainId, company: nextCompanyId }
     },
-    [addDomain, addRealEstate, form]
+    [addDomain, addRealEstate, form, typeTemplates]
   )
 
   const handleSubmit = async () => {

--- a/common/components/Forms/AddPaymentForm/CompanySelect.module.scss
+++ b/common/components/Forms/AddPaymentForm/CompanySelect.module.scss
@@ -1,0 +1,15 @@
+.companyRow {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.companyField {
+  flex: 1;
+  min-width: 0;
+}
+
+.emailField {
+  flex: 1;
+  min-width: 0;
+}

--- a/common/components/Forms/AddPaymentForm/CompanySelect.test.tsx
+++ b/common/components/Forms/AddPaymentForm/CompanySelect.test.tsx
@@ -7,25 +7,14 @@ jest.mock('@common/api/realestateApi/realestate.api', () => ({
   useGetAllRealEstateQuery: jest.fn(),
 }))
 
-jest.mock('@components/UI/RealEstateComponents/RealEstateModal', () => ({
-  __esModule: true,
-  default: ({
-    chosenRealEstate,
-  }: {
-    chosenRealEstate: { domain: string; street?: string } | null
-  }) => (
-    <div data-testid="real-estate-modal">
-      modal:{chosenRealEstate?.domain}:{chosenRealEstate?.street}
-    </div>
-  ),
-}))
-
 const mockedQuery = useGetAllRealEstateQuery as jest.Mock
 
 const Wrapper = ({
   initialValues = { domain: 'd1', street: 's1' },
+  allowCreate = false,
 }: {
   initialValues?: { domain?: string; street?: string }
+  allowCreate?: boolean
 }) => {
   const [form] = Form.useForm()
   return (
@@ -36,63 +25,15 @@ const Wrapper = ({
       <Form.Item name="street" hidden>
         <Input />
       </Form.Item>
-      <CompanySelect form={form} />
+      <CompanySelect form={form} allowCreate={allowCreate} />
     </Form>
   )
 }
 
-const openCompanyDropdown = () =>
-  fireEvent.mouseDown(screen.getByRole('combobox'))
+const getCompanyInput = () => screen.getByRole('combobox')
 
 describe('CompanySelect — поле вибору компанії', () => {
   afterEach(() => jest.clearAllMocks())
-
-  it('показує «Немає компанії? Створити» у дропдауні, коли компаній немає', () => {
-    mockedQuery.mockReturnValue({ data: { data: [] }, isLoading: false })
-
-    render(<Wrapper />)
-    openCompanyDropdown()
-
-    expect(screen.getByText('Немає компанії? Створити')).toBeInTheDocument()
-  })
-
-  it('показує «Створити компанію», коли компанія вже існує', () => {
-    mockedQuery.mockReturnValue({
-      data: { data: [{ _id: 'c1', companyName: 'Acme' }] },
-      isLoading: false,
-    })
-
-    render(<Wrapper />)
-    openCompanyDropdown()
-
-    expect(screen.getByText('Створити компанію')).toBeInTheDocument()
-    expect(
-      screen.queryByText('Немає компанії? Створити')
-    ).not.toBeInTheDocument()
-  })
-
-  it('кнопка створення доступна навіть без обраної адреси', () => {
-    mockedQuery.mockReturnValue({ data: { data: [] }, isLoading: false })
-
-    render(<Wrapper initialValues={{ domain: 'd1' }} />)
-    openCompanyDropdown()
-
-    expect(screen.getByText('Немає компанії? Створити')).toBeInTheDocument()
-  })
-
-  it('відкриває модалку компанії з підставленими доменом і адресою', () => {
-    mockedQuery.mockReturnValue({ data: { data: [] }, isLoading: false })
-
-    render(<Wrapper />)
-    openCompanyDropdown()
-
-    expect(screen.queryByTestId('real-estate-modal')).not.toBeInTheDocument()
-
-    fireEvent.click(screen.getByText('Немає компанії? Створити'))
-
-    const modal = screen.getByTestId('real-estate-modal')
-    expect(modal).toHaveTextContent('modal:d1:s1')
-  })
 
   it('показує заглушку, коли надавача послуг ще не обрано', () => {
     mockedQuery.mockReturnValue({ data: { data: [] }, isLoading: false })
@@ -102,5 +43,55 @@ describe('CompanySelect — поле вибору компанії', () => {
     expect(
       screen.getByText('Спершу оберіть надавача послуг')
     ).toBeInTheDocument()
+  })
+
+  it('рендерить наявні компанії як опції', () => {
+    mockedQuery.mockReturnValue({
+      data: {
+        data: [
+          { _id: 'c1', companyName: 'Acme' },
+          { _id: 'c2', companyName: 'Globex' },
+        ],
+      },
+      isLoading: false,
+    })
+
+    render(<Wrapper />)
+    fireEvent.mouseDown(getCompanyInput())
+
+    expect(screen.getByText('Acme')).toBeInTheDocument()
+    expect(screen.getByText('Globex')).toBeInTheDocument()
+  })
+
+  it('при allowCreate показує кнопку створення в дропдауні', () => {
+    mockedQuery.mockReturnValue({ data: { data: [] }, isLoading: false })
+
+    render(<Wrapper allowCreate />)
+    fireEvent.mouseDown(getCompanyInput())
+
+    expect(screen.getByText('Створити нову компанію')).toBeInTheDocument()
+  })
+
+  it('кнопка створення показує інпути назви та пошти', () => {
+    mockedQuery.mockReturnValue({ data: { data: [] }, isLoading: false })
+
+    render(<Wrapper allowCreate />)
+    fireEvent.mouseDown(getCompanyInput())
+    fireEvent.click(screen.getByText('Створити нову компанію'))
+
+    expect(
+      screen.getByPlaceholderText('Назва нової компанії')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Пошта компанії')).toBeInTheDocument()
+  })
+
+  it('без allowCreate не показує кнопку створення', () => {
+    mockedQuery.mockReturnValue({ data: { data: [] }, isLoading: false })
+
+    render(<Wrapper />)
+    fireEvent.mouseDown(getCompanyInput())
+
+    expect(screen.queryByText('Створити нову компанію')).not.toBeInTheDocument()
+    expect(screen.queryByText('Пошта компанії')).not.toBeInTheDocument()
   })
 })

--- a/common/components/Forms/AddPaymentForm/CompanySelect.tsx
+++ b/common/components/Forms/AddPaymentForm/CompanySelect.tsx
@@ -1,138 +1,212 @@
 import { validateField } from '@assets/features/validators'
 import { useGetAllRealEstateQuery } from '@common/api/realestateApi/realestate.api'
 import { IRealestate } from '@common/api/realestateApi/realestate.api.types'
-import RealEstateModal from '@components/UI/RealEstateComponents/RealEstateModal'
 import { PlusOutlined } from '@ant-design/icons'
-import { Button, Divider, Form, Select } from 'antd'
+import { Button, Divider, Form, Input, Select } from 'antd'
 import { FormInstance } from 'antd/es/form/Form'
 import { useEffect, useMemo, useState } from 'react'
+import {
+  getNewEntityName,
+  isNewEntityValue,
+  makeNewEntityValue,
+} from '@utils/inlineCreate'
+import s from './CompanySelect.module.scss'
+
+const COMPANY_TOOLTIP = 'Кому виставляється рахунок — орендар/платник.'
+const EMAIL_TOOLTIP = 'Пошта, яка відображатиметься в рахунку як отримувач.'
 
 interface Props {
   form: FormInstance
   edit?: boolean
   company?: string | Partial<IRealestate>
+  // When true the user can create a brand-new company inline: a persistent
+  // "Створити нову компанію" button in the dropdown switches the field into a
+  // name + email input mode. The value becomes a `new::` sentinel that
+  // AddPaymentModal materializes into a real company on submit.
+  allowCreate?: boolean
 }
 
-export default function CompanySelect({ form, edit, company }: Props) {
+export default function CompanySelect({
+  form,
+  edit,
+  company,
+  allowCreate,
+}: Props) {
   const domainId = Form.useWatch('domain', form)
-  const streetId = Form.useWatch('street', form)
 
   if (!domainId) {
     return (
-      <Form.Item label="Компанія">
+      <Form.Item label="Компанія" tooltip={COMPANY_TOOLTIP}>
         <Select placeholder="Спершу оберіть надавача послуг" disabled />
       </Form.Item>
     )
   }
 
   return (
-    <RealEstateDataFetcher
+    <CompanyPicker
       domainId={domainId}
-      streetId={streetId}
       form={form}
       edit={edit}
       company={company}
+      allowCreate={allowCreate}
     />
   )
 }
 
-interface RealEstateDataFetcherProps {
+interface CompanyPickerProps {
   domainId: string
-  streetId?: string
   form: FormInstance
   edit?: boolean
   company?: string | Partial<IRealestate>
+  allowCreate?: boolean
 }
 
-function RealEstateDataFetcher({
+function CompanyPicker({
   domainId,
-  streetId,
   form,
   edit,
   company,
-}: RealEstateDataFetcherProps) {
-  const { data, isLoading, refetch } = useGetAllRealEstateQuery({
-    domainId,
-    streetId,
-  })
+  allowCreate,
+}: CompanyPickerProps) {
+  const streetId = Form.useWatch('street', form)
+  const companyValue = Form.useWatch('company', form)
+  const [search, setSearch] = useState('')
+
+  const isNewDomain = isNewEntityValue(domainId)
+  const isNewCompany = isNewEntityValue(companyValue)
+
+  const { data, isLoading } = useGetAllRealEstateQuery(
+    { domainId, streetId },
+    { skip: isNewDomain }
+  )
 
   const companies = useMemo(() => data?.data ?? [], [data])
 
-  const [isCompanyModalOpen, setIsCompanyModalOpen] = useState(false)
-
   useEffect(() => {
-    if (!edit) {
-      if (companies.length === 1) {
-        form.setFieldValue('company', companies[0]._id)
-      } else if (companies.length > 0 && company) {
-        const companyId = typeof company === 'object' ? company._id : company
-        if (form.getFieldValue('company') !== companyId) {
-          form.setFieldValue('company', companyId)
-        }
+    if (edit) return
+    // Never override a typed "new" company with an auto-pick.
+    if (isNewEntityValue(form.getFieldValue('company'))) return
+    if (companies.length === 1) {
+      form.setFieldValue('company', companies[0]._id)
+    } else if (companies.length > 0 && company) {
+      const companyId = typeof company === 'object' ? company._id : company
+      if (form.getFieldValue('company') !== companyId) {
+        form.setFieldValue('company', companyId)
       }
     }
   }, [companies, company, edit, form])
 
-  const createCompanyLabel =
-    companies.length === 0 ? 'Немає компанії? Створити' : 'Створити компанію'
+  useEffect(() => {
+    // A brand-new provider has no companies, so jump straight into create mode.
+    if (edit || !allowCreate || !isNewDomain) return
+    if (!form.getFieldValue('company')) {
+      form.setFieldValue('company', makeNewEntityValue(''))
+    }
+  }, [isNewDomain, allowCreate, edit, form])
+
+  const options = useMemo(
+    () => companies.map((i) => ({ value: i._id, label: i.companyName })),
+    [companies]
+  )
+
+  const enterCreateMode = () => {
+    form.setFieldValue('company', makeNewEntityValue(search.trim()))
+    setSearch('')
+  }
+
+  const exitCreateMode = () => {
+    form.setFieldValue('company', undefined)
+    form.setFieldValue('companyEmail', undefined)
+  }
+
+  if (isNewCompany) {
+    return (
+      <>
+        <div className={s.companyRow}>
+          <Form.Item
+            name="company"
+            label="Компанія"
+            tooltip={COMPANY_TOOLTIP}
+            className={s.companyField}
+            getValueProps={(v) => ({
+              value: isNewEntityValue(v) ? getNewEntityName(v) : '',
+            })}
+            normalize={(input) => makeNewEntityValue(input ?? '')}
+            rules={[
+              {
+                validator: (_, v) =>
+                  getNewEntityName(v ?? '').trim()
+                    ? Promise.resolve()
+                    : Promise.reject(new Error('Вкажіть назву компанії')),
+              },
+            ]}
+          >
+            <Input placeholder="Назва нової компанії" />
+          </Form.Item>
+          <Form.Item
+            name="companyEmail"
+            label="Пошта компанії"
+            tooltip={EMAIL_TOOLTIP}
+            rules={validateField('email')}
+            className={s.emailField}
+          >
+            <Input placeholder="email@example.com" />
+          </Form.Item>
+        </div>
+        {!isNewDomain && (
+          <Button
+            type="link"
+            size="small"
+            style={{ padding: 0, marginTop: -4, marginBottom: 8 }}
+            onClick={exitCreateMode}
+          >
+            ← обрати наявну
+          </Button>
+        )}
+      </>
+    )
+  }
 
   return (
-    <>
-      <Form.Item
-        name="company"
-        label="Компанія"
-        rules={validateField('required')}
-      >
-        <Select
-          filterSort={(optionA, optionB) =>
-            (optionA?.label ?? '')
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              ?.toLowerCase()
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              .localeCompare((optionB?.label ?? '').toLowerCase())
-          }
-          filterOption={(input, option) =>
-            (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
-          }
-          options={companies.map((i) => ({
-            value: i._id,
-            label: i.companyName,
-          }))}
-          optionFilterProp="label"
-          placeholder="Пошук компанії"
-          loading={isLoading}
-          showSearch
-          popupRender={(menu) => (
-            <>
-              {menu}
-              <Divider style={{ margin: '8px 0' }} />
-              <Button
-                type="text"
-                block
-                icon={<PlusOutlined />}
-                style={{ textAlign: 'left' }}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => setIsCompanyModalOpen(true)}
-              >
-                {createCompanyLabel}
-              </Button>
-            </>
-          )}
-        />
-      </Form.Item>
-
-      {isCompanyModalOpen && (
-        <RealEstateModal
-          chosenRealEstate={{ domain: domainId, street: streetId }}
-          editable
-          closeModal={() => {
-            setIsCompanyModalOpen(false)
-            refetch()
-          }}
-        />
-      )}
-    </>
+    <Form.Item
+      name="company"
+      label="Компанія"
+      tooltip={COMPANY_TOOLTIP}
+      rules={validateField('required')}
+    >
+      <Select
+        options={options}
+        optionFilterProp="label"
+        placeholder="Пошук компанії"
+        loading={isLoading}
+        showSearch
+        allowClear
+        searchValue={search}
+        onSearch={setSearch}
+        onChange={() => setSearch('')}
+        popupRender={
+          allowCreate
+            ? (menu) => (
+                <>
+                  {menu}
+                  <Divider style={{ margin: '8px 0' }} />
+                  <Button
+                    type="text"
+                    block
+                    icon={<PlusOutlined />}
+                    style={{ textAlign: 'left' }}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={enterCreateMode}
+                  >
+                    {search.trim()
+                      ? `Створити «${search.trim()}»`
+                      : 'Створити нову компанію'}
+                  </Button>
+                </>
+              )
+            : undefined
+        }
+      />
+    </Form.Item>
   )
 }

--- a/common/components/Forms/AddPaymentForm/InvoiceCreationDate.tsx
+++ b/common/components/Forms/AddPaymentForm/InvoiceCreationDate.tsx
@@ -8,7 +8,11 @@ dayjs.locale('uk')
 export default function InvoiceCreationDate({ edit }) {
   return (
     <ConfigProvider locale={ukUA}>
-      <Form.Item name="invoiceCreationDate" label="Оплата від">
+      <Form.Item
+        name="invoiceCreationDate"
+        label="Оплата від"
+        tooltip="Дата виставлення рахунку."
+      >
         <DatePicker format="DD.MM.YYYY" disabled={edit} />
       </Form.Item>
     </ConfigProvider>

--- a/common/components/Forms/AddPaymentForm/InvoiceNumber.tsx
+++ b/common/components/Forms/AddPaymentForm/InvoiceNumber.tsx
@@ -18,7 +18,11 @@ export default function InvoiceNumber({ form, paymentActions }) {
   }, [newInvoiceNumber]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <Form.Item name="invoiceNumber" label="№ інвойса">
+    <Form.Item
+      name="invoiceNumber"
+      label="№ інвойса"
+      tooltip="Порядковий номер рахунку. Підставляється автоматично, можна змінити."
+    >
       <InputNumber
         parser={inputNumberParser}
         style={{ minWidth: '166px' }}

--- a/common/components/Forms/AddPaymentForm/MonthServiceSelect.tsx
+++ b/common/components/Forms/AddPaymentForm/MonthServiceSelect.tsx
@@ -86,6 +86,7 @@ const MonthServiceSelect: React.FC<MonthServiceSelectProps> = ({
     <Form.Item
       name="monthService"
       label="Місяць"
+      tooltip="Розрахунковий період, за який виставляється рахунок."
       rules={validateField('required')}
     >
       <Select

--- a/common/components/Forms/AddPaymentForm/index.tsx
+++ b/common/components/Forms/AddPaymentForm/index.tsx
@@ -47,25 +47,45 @@ function AddPaymentForm({
 
   const showChangelog = changelogOptions.length > 0
 
+  // On a fresh invoice the user may type a brand-new provider/company name and
+  // have it created on submit (see AddPaymentModal). Disabled while editing.
+  const allowCreate = !edit && !preview
+
   return (
     <>
-      <DomainsSelect form={form} edit={edit} />
-      <AddressesSelect
-        form={form}
-        edit={edit}
-        street={company?.street?._id}
-        required={false}
-      />
-      <MonthServiceSelect form={form} edit={edit} />
-      <CompanySelect form={form} edit={edit} company={payment?.company} />
-      <PaymentTypeSelect />
-      <div className={s.invoiceRow}>
+      <div data-invoice-tour="domain">
+        <DomainsSelect form={form} edit={edit} allowCreate={allowCreate} />
+      </div>
+      <div data-invoice-tour="address">
+        <AddressesSelect
+          form={form}
+          edit={edit}
+          street={company?.street?._id}
+          required={false}
+        />
+      </div>
+      <div data-invoice-tour="month">
+        <MonthServiceSelect form={form} edit={edit} />
+      </div>
+      <div data-invoice-tour="company">
+        <CompanySelect
+          form={form}
+          edit={edit}
+          company={payment?.company}
+          allowCreate={allowCreate}
+        />
+      </div>
+      <div data-invoice-tour="operation">
+        <PaymentTypeSelect />
+      </div>
+      <div className={s.invoiceRow} data-invoice-tour="invoice-meta">
         <InvoiceNumber form={form} paymentActions={selectedActions} />
-        <Form.Item name="currency" label=" ">
+        <Form.Item name="currency" label="Валюта">
           <Select
             className={s.currencySelect}
             options={CURRENCY_SELECT_OPTIONS}
             disabled={preview}
+            popupMatchSelectWidth={false}
           />
         </Form.Item>
       </div>
@@ -96,10 +116,11 @@ function AddPaymentForm({
       ) : null}
 
       {operation === Operations.Credit ? (
-        <>
+        <div data-invoice-tour="amount">
           <Form.Item
             name="generalSum"
             label="Сума"
+            tooltip="Загальна сума оплати."
             rules={validateField('paymentPrice')}
           >
             <InputNumber
@@ -112,6 +133,7 @@ function AddPaymentForm({
           <Form.Item
             name="description"
             label="Опис"
+            tooltip="Призначення платежу."
             rules={validateField('required')}
           >
             <Input.TextArea
@@ -120,12 +142,12 @@ function AddPaymentForm({
               disabled={preview}
             />
           </Form.Item>
-        </>
+        </div>
       ) : (
-        <>
+        <div data-invoice-tour="amount">
           <PaymentPricesTable preview={preview} service={service} />
           <PaymentTotal form={form} />
-        </>
+        </div>
       )}
     </>
   )

--- a/common/components/Forms/AddPaymentForm/style.module.scss
+++ b/common/components/Forms/AddPaymentForm/style.module.scss
@@ -36,5 +36,5 @@
 }
 
 .currencySelect {
-  width: 50px;
+  width: 90px;
 }

--- a/common/components/Forms/GroupedReceiptForm/useInvoiceTemplateDescriptions.ts
+++ b/common/components/Forms/GroupedReceiptForm/useInvoiceTemplateDescriptions.ts
@@ -4,6 +4,7 @@ import {
   IInvoiceTemplateOverrides,
 } from '@common/api/invoiceTemplateApi/invoiceTemplate.api.types'
 import { usePaymentContext } from '@components/AddPaymentModal'
+import { isNewEntityValue } from '@utils/inlineCreate'
 import { templateMap } from './templateMap'
 
 interface Input {
@@ -35,12 +36,15 @@ export function useInvoiceTemplateDescriptions({
 }: Input = {}): InvoiceTemplateDescriptions {
   const { template, company } = usePaymentContext()
 
-  const domainId: string =
+  const rawDomainId: string =
     (typeof data?.domain === 'object' ? data?.domain?._id : data?.domain) ||
     (typeof company?.domain === 'object'
       ? (company.domain as any)?._id
       : company?.domain) ||
     ''
+
+  // A not-yet-created provider (held as a `new::` sentinel) has no templates.
+  const domainId = isNewEntityValue(rawDomainId) ? '' : rawDomainId
 
   const { data: customTemplatesRes } = useGetInvoiceTemplatesQuery(
     { domainId },

--- a/common/components/Pages/DashboardLanding/index.tsx
+++ b/common/components/Pages/DashboardLanding/index.tsx
@@ -9,19 +9,14 @@ import { Footer } from '@components/Layouts/Footer'
 import {
   useGetCurrentUserQuery,
   useGetUserByIdQuery,
-  userApi,
 } from '@common/api/userApi/user.api'
-import { useAppDispatch } from '@modules/store/hooks'
 import { useRouter } from 'next/router'
 import { Roles } from '@utils/constants'
-import { IExtendedDomain } from '@common/api/domainApi/domain.api.types'
-import DomainModal from '@components/UI/DomainsComponents/DomainModal'
 import s from './DashboardLanding.module.scss'
 
 const { Title, Text } = Typography
 
 const DashboardLanding = () => {
-  const dispatch = useAppDispatch()
   const router = useRouter()
   const { data: user } = useGetCurrentUserQuery()
   // The by-id endpoint returns adminDomains/adminCompanies, which lets us
@@ -31,10 +26,7 @@ const DashboardLanding = () => {
     skip: !user?._id,
   })
   const [welcomeOpen, setWelcomeOpen] = useState(false)
-  const [domainModalOpen, setDomainModalOpen] = useState(false)
-  const [invoicePromptOpen, setInvoicePromptOpen] = useState(false)
   const [paymentModalOpen, setPaymentModalOpen] = useState(false)
-  const [createdDomainId, setCreatedDomainId] = useState<string>()
 
   useEffect(() => {
     if (!fullUser) return
@@ -48,35 +40,15 @@ const DashboardLanding = () => {
     setWelcomeOpen(Boolean(ownsNothing && !isGlobalAdmin))
   }, [fullUser, user])
 
-  const handleCreateProvider = () => {
-    setWelcomeOpen(false)
-    setDomainModalOpen(true)
-  }
-
-  const handleDomainModalClose = (createdDomain?: IExtendedDomain) => {
-    setDomainModalOpen(false)
-    // Creating a domain adds the user to its adminEmails, which promotes them
-    // to DomainAdmin on the next getCurrentUser call. Refresh the user so the
-    // new role (and the data-driven modal visibility) updates without a reload.
-    dispatch(userApi.util.invalidateTags(['User']))
-    if (createdDomain?._id) {
-      setCreatedDomainId(createdDomain._id)
-      setInvoicePromptOpen(true)
-    }
-  }
-
   const handleStartFirstInvoice = () => {
-    setInvoicePromptOpen(false)
+    setWelcomeOpen(false)
     setPaymentModalOpen(true)
-  }
-
-  const handleDeclineFirstInvoice = () => {
-    setInvoicePromptOpen(false)
-    router.reload()
   }
 
   const handlePaymentModalClose = () => {
     setPaymentModalOpen(false)
+    // The first invoice creates a provider+company on the fly, which promotes
+    // the user to DomainAdmin. Reload so the new role and data take effect.
     router.reload()
   }
 
@@ -150,47 +122,16 @@ const DashboardLanding = () => {
             type="primary"
             block
             size="large"
-            onClick={handleCreateProvider}
+            onClick={handleStartFirstInvoice}
           >
-            Створити надавача послуг
+            Створити перший рахунок
           </Button>
-        </Space>
-      </Modal>
-
-      {domainModalOpen && (
-        <DomainModal
-          currentDomain={null as unknown as IExtendedDomain}
-          editable
-          closeModal={handleDomainModalClose}
-        />
-      )}
-
-      <Modal
-        open={invoicePromptOpen}
-        centered
-        width={420}
-        onCancel={handleDeclineFirstInvoice}
-        footer={[
-          <Button key="later" onClick={handleDeclineFirstInvoice}>
-            Пізніше
-          </Button>,
-          <Button key="yes" type="primary" onClick={handleStartFirstInvoice}>
-            Так
-          </Button>,
-        ]}
-      >
-        <Space direction="vertical" size="small" style={{ width: '100%' }}>
-          <Title level={4} style={{ marginBottom: 0 }}>
-            Надавача послуг створено!
-          </Title>
-          <Text type="secondary">Створити перший рахунок?</Text>
         </Space>
       </Modal>
 
       {paymentModalOpen && (
         <AddPaymentModal
           paymentActions={{ edit: false, preview: false }}
-          preselectedDomain={createdDomainId}
           closeModal={handlePaymentModalClose}
         />
       )}

--- a/common/components/Tables/EditInvoiceTable/EditInvoiceTable.test.tsx
+++ b/common/components/Tables/EditInvoiceTable/EditInvoiceTable.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { Form } from 'antd'
+import { EditInvoicesTable_unstable } from './index'
+
+jest.mock('@common/api/customServicesApi/customServices.api', () => ({
+  useGetCustomServicesByDomainQuery: () => ({
+    data: { data: [] },
+    isLoading: false,
+  }),
+}))
+
+const Wrapper = ({ editable = true }: { editable?: boolean }) => {
+  const [form] = Form.useForm()
+  return (
+    <Form form={form}>
+      <EditInvoicesTable_unstable
+        form={form}
+        editable={editable}
+        domainId="d1"
+      />
+    </Form>
+  )
+}
+
+describe('EditInvoicesTable — порожній стан', () => {
+  it('показує підказку як додати послугу, коли рядків немає і таблиця редагована', () => {
+    render(<Wrapper editable />)
+
+    expect(screen.getByText(/Ще немає послуг/)).toBeInTheDocument()
+  })
+
+  it('не показує підказку, коли таблиця нередагована', () => {
+    render(<Wrapper editable={false} />)
+
+    expect(screen.queryByText(/Ще немає послуг/)).not.toBeInTheDocument()
+  })
+})

--- a/common/components/Tables/EditInvoiceTable/index.tsx
+++ b/common/components/Tables/EditInvoiceTable/index.tsx
@@ -4,6 +4,7 @@ import { IPayment } from '@common/api/paymentApi/payment.api.types'
 import { IRealestate } from '@common/api/realestateApi/realestate.api.types'
 import { IService } from '@common/api/serviceApi/service.api.types'
 import { ServiceType } from '@utils/constants'
+import { isNewEntityValue } from '@utils/inlineCreate'
 import {
   catalogRowToSelectOption,
   flattenDomainCatalogServices,
@@ -11,7 +12,7 @@ import {
   IInvoicePriceContext,
   invoiceLineExcludeKey,
 } from '@utils/domain/domain-invoice-selector'
-import { Form, FormInstance, Select, Table } from 'antd'
+import { Empty, Form, FormInstance, Select, Table } from 'antd'
 import React, { useCallback, useMemo } from 'react'
 
 import Cleaning from './Cleaning'
@@ -161,6 +162,30 @@ export const EditInvoicesTable_unstable: React.FC<EditInvoicesTableProps> = ({
             size="small"
             dataSource={fields}
             pagination={false}
+            locale={
+              editable
+                ? {
+                    emptyText: (
+                      <Empty
+                        image={Empty.PRESENTED_IMAGE_SIMPLE}
+                        description={
+                          <span
+                            style={{
+                              maxWidth: 360,
+                              display: 'inline-block',
+                            }}
+                          >
+                            Ще немає послуг. Додайте рядок нижче: оберіть з
+                            каталогу або «Власне», вкажіть назву, кількість і
+                            ціну — сума порахується автоматично (ціна ×
+                            кількість).
+                          </span>
+                        }
+                      />
+                    ),
+                  }
+                : undefined
+            }
             footer={
               editable
                 ? () => (
@@ -195,20 +220,26 @@ export const InvoiceSelector: React.FC<{
   excludeKeys?: string[]
   onSelect?: (payload: IInvoiceLineAddPayload) => void
 }> = ({ service, company, prevPayment, domainId, excludeKeys, onSelect }) => {
-  const resolvedDomainId = service?.domain?._id
+  const rawDomainId = service?.domain?._id
     ? String(service.domain._id)
     : domainId
       ? String(domainId)
       : undefined
 
+  // A brand-new (not-yet-created) provider has no catalog to fetch, but the user
+  // still needs the "Власне" option to add custom lines to the first invoice.
+  const isNewDomain = isNewEntityValue(rawDomainId)
+  const catalogDomainId = isNewDomain ? undefined : rawDomainId
+  const hasDomainContext = !!rawDomainId
+
   const { data: catalogRes, isLoading } = useGetCustomServicesByDomainQuery(
-    { domainId: resolvedDomainId ? [resolvedDomainId] : undefined },
-    { skip: !resolvedDomainId }
+    { domainId: catalogDomainId ? [catalogDomainId] : undefined },
+    { skip: !catalogDomainId }
   )
 
   const options = useMemo(() => {
-    if (!resolvedDomainId) return []
-    const groups = catalogRes?.data ?? []
+    if (!hasDomainContext) return []
+    const groups = catalogDomainId ? (catalogRes?.data ?? []) : []
     const rows = flattenDomainCatalogServices(groups)
     const priceContext: IInvoicePriceContext = {
       company,
@@ -224,7 +255,15 @@ export const InvoiceSelector: React.FC<{
       payload: { type: ServiceType.Custom },
     }
     return [...catalogOptions, customOption]
-  }, [catalogRes, resolvedDomainId, excludeKeys, company, service, prevPayment])
+  }, [
+    catalogRes,
+    catalogDomainId,
+    hasDomainContext,
+    excludeKeys,
+    company,
+    service,
+    prevPayment,
+  ])
 
   const handleSelect = useCallback(
     (value: string) => {
@@ -244,20 +283,20 @@ export const InvoiceSelector: React.FC<{
       style={{ width: '100%' }}
       suffixIcon={<PlusOutlined />}
       placeholder={
-        resolvedDomainId
+        hasDomainContext
           ? 'Додати поле з каталогу домену...'
           : 'Немає домену в сервісі — каталог недоступний'
       }
       onSelect={handleSelect}
       value={undefined}
       options={options}
-      loading={!!resolvedDomainId && isLoading}
-      disabled={!resolvedDomainId || isLoading}
+      loading={!!catalogDomainId && isLoading}
+      disabled={!hasDomainContext || (!!catalogDomainId && isLoading)}
       allowClear
       showSearch
       optionFilterProp="label"
       notFoundContent={
-        resolvedDomainId && !isLoading
+        catalogDomainId && !isLoading
           ? 'У групах домену немає послуг'
           : undefined
       }

--- a/common/components/UI/ModalWindow/index.tsx
+++ b/common/components/UI/ModalWindow/index.tsx
@@ -14,7 +14,7 @@ interface Props {
   style?: React.CSSProperties
   open?: boolean
   okButtonProps?: ButtonProps
-  title: string
+  title: React.ReactNode
   preview?: boolean
   destroyOnHidden?: boolean
   width?: number | string

--- a/common/components/UI/Reusable/AddressesSelect.tsx
+++ b/common/components/UI/Reusable/AddressesSelect.tsx
@@ -1,6 +1,7 @@
 import { validateField } from '@assets/features/validators'
 import { useGetAllStreetsQuery } from '@common/api/streetApi/street.api'
 import { AppRoutes } from '@utils/constants'
+import { isNewEntityValue } from '@utils/inlineCreate'
 import { Form, FormInstance, Select, Tooltip } from 'antd'
 import Link from 'next/link'
 import { CSSProperties, useEffect, useMemo } from 'react'
@@ -30,7 +31,10 @@ const AddressesSelect: React.FC<AddressesSelectProps> = ({
     data: streets = [],
     isLoading: isStreetsLoading,
     isError: isStreetsError,
-  } = useGetAllStreetsQuery({ domainId }, { skip: !domainId })
+  } = useGetAllStreetsQuery(
+    { domainId },
+    { skip: !domainId || isNewEntityValue(domainId) }
+  )
 
   const options = useMemo(() => {
     return streets.map((i) => ({
@@ -92,6 +96,7 @@ const AddressesSelect: React.FC<AddressesSelectProps> = ({
       <Form.Item
         name="street"
         label="Адреса"
+        tooltip="Об'єкт (адреса), за яким нараховується оплата. Необов'язково."
         rules={required ? validateField('required') : []}
       >
         <Select

--- a/common/components/UI/Reusable/DomainsSelect.module.scss
+++ b/common/components/UI/Reusable/DomainsSelect.module.scss
@@ -1,0 +1,15 @@
+.createRow {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.nameField {
+  flex: 1;
+  min-width: 0;
+}
+
+.templateField {
+  flex: 1.6;
+  min-width: 0;
+}

--- a/common/components/UI/Reusable/DomainsSelect.test.tsx
+++ b/common/components/UI/Reusable/DomainsSelect.test.tsx
@@ -1,13 +1,18 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { Form } from 'antd'
 import DomainsSelect from './DomainsSelect'
-import { useGetDomainsQuery } from '@common/api/domainApi/domain.api'
+import {
+  useGetDomainsQuery,
+  useGetDomainTypeTemplatesQuery,
+} from '@common/api/domainApi/domain.api'
 
 jest.mock('@common/api/domainApi/domain.api', () => ({
   useGetDomainsQuery: jest.fn(),
+  useGetDomainTypeTemplatesQuery: jest.fn(),
 }))
 
-const mockedQuery = useGetDomainsQuery as jest.Mock
+const mockDomains = useGetDomainsQuery as jest.Mock
+const mockTemplates = useGetDomainTypeTemplatesQuery as jest.Mock
 
 const Wrapper = ({ allowCreate = false }: { allowCreate?: boolean }) => {
   const [form] = Form.useForm()
@@ -20,15 +25,19 @@ const Wrapper = ({ allowCreate = false }: { allowCreate?: boolean }) => {
 
 const getDomainInput = () => screen.getByRole('combobox')
 
+const startCreate = () => {
+  fireEvent.mouseDown(getDomainInput())
+  fireEvent.click(screen.getByText('Створити нового надавача'))
+}
+
 describe('DomainsSelect — поле надавача послуг', () => {
+  beforeEach(() => {
+    mockTemplates.mockReturnValue({ data: [], isLoading: false })
+  })
   afterEach(() => jest.clearAllMocks())
 
   it('при allowCreate показує кнопку створення в дропдауні', () => {
-    mockedQuery.mockReturnValue({
-      data: [],
-      isLoading: false,
-      isError: false,
-    })
+    mockDomains.mockReturnValue({ data: [], isLoading: false, isError: false })
 
     render(<Wrapper allowCreate />)
     fireEvent.mouseDown(getDomainInput())
@@ -36,24 +45,39 @@ describe('DomainsSelect — поле надавача послуг', () => {
     expect(screen.getByText('Створити нового надавача')).toBeInTheDocument()
   })
 
-  it('кнопка створення показує інпут назви', () => {
-    mockedQuery.mockReturnValue({
-      data: [],
+  it('кнопка створення показує інпут назви та селектор напрямку', () => {
+    mockDomains.mockReturnValue({ data: [], isLoading: false, isError: false })
+    mockTemplates.mockReturnValue({
+      data: [{ _id: 't1', name: 'Комунальні', isBuiltIn: true, groups: [] }],
       isLoading: false,
-      isError: false,
     })
 
     render(<Wrapper allowCreate />)
-    fireEvent.mouseDown(getDomainInput())
-    fireEvent.click(screen.getByText('Створити нового надавача'))
+    startCreate()
 
-    expect(
-      screen.getByPlaceholderText('Назва нового надавача послуг')
-    ).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Назва надавача')).toBeInTheDocument()
+    expect(screen.getByText('Напрямок послуг')).toBeInTheDocument()
+    // default value «Без послуг» is shown as the selected option
+    expect(screen.getByText('Без послуг')).toBeInTheDocument()
+  })
+
+  it('у списку напрямків є вбудований шаблон', () => {
+    mockDomains.mockReturnValue({ data: [], isLoading: false, isError: false })
+    mockTemplates.mockReturnValue({
+      data: [{ _id: 't1', name: 'Комунальні', isBuiltIn: true, groups: [] }],
+      isLoading: false,
+    })
+
+    render(<Wrapper allowCreate />)
+    startCreate()
+    // the only combobox in create mode is the service-type select
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+
+    expect(screen.getByText('Комунальні')).toBeInTheDocument()
   })
 
   it('без allowCreate не показує кнопку створення', () => {
-    mockedQuery.mockReturnValue({
+    mockDomains.mockReturnValue({
       data: [
         { _id: 'd1', name: 'Alpha' },
         { _id: 'd2', name: 'Beta' },

--- a/common/components/UI/Reusable/DomainsSelect.test.tsx
+++ b/common/components/UI/Reusable/DomainsSelect.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Form } from 'antd'
+import DomainsSelect from './DomainsSelect'
+import { useGetDomainsQuery } from '@common/api/domainApi/domain.api'
+
+jest.mock('@common/api/domainApi/domain.api', () => ({
+  useGetDomainsQuery: jest.fn(),
+}))
+
+const mockedQuery = useGetDomainsQuery as jest.Mock
+
+const Wrapper = ({ allowCreate = false }: { allowCreate?: boolean }) => {
+  const [form] = Form.useForm()
+  return (
+    <Form form={form}>
+      <DomainsSelect form={form} allowCreate={allowCreate} />
+    </Form>
+  )
+}
+
+const getDomainInput = () => screen.getByRole('combobox')
+
+describe('DomainsSelect — поле надавача послуг', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('при allowCreate показує кнопку створення в дропдауні', () => {
+    mockedQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<Wrapper allowCreate />)
+    fireEvent.mouseDown(getDomainInput())
+
+    expect(screen.getByText('Створити нового надавача')).toBeInTheDocument()
+  })
+
+  it('кнопка створення показує інпут назви', () => {
+    mockedQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<Wrapper allowCreate />)
+    fireEvent.mouseDown(getDomainInput())
+    fireEvent.click(screen.getByText('Створити нового надавача'))
+
+    expect(
+      screen.getByPlaceholderText('Назва нового надавача послуг')
+    ).toBeInTheDocument()
+  })
+
+  it('без allowCreate не показує кнопку створення', () => {
+    mockedQuery.mockReturnValue({
+      data: [
+        { _id: 'd1', name: 'Alpha' },
+        { _id: 'd2', name: 'Beta' },
+      ],
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<Wrapper />)
+    fireEvent.mouseDown(getDomainInput())
+
+    expect(
+      screen.queryByText('Створити нового надавача')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/common/components/UI/Reusable/DomainsSelect.tsx
+++ b/common/components/UI/Reusable/DomainsSelect.tsx
@@ -1,23 +1,37 @@
 import { useGetDomainsQuery } from '@common/api/domainApi/domain.api'
 import { validateField } from '@assets/features/validators'
-import { Form, FormInstance, Select } from 'antd'
+import { PlusOutlined } from '@ant-design/icons'
+import { Button, Divider, Form, FormInstance, Input, Select } from 'antd'
 import { useEffect, useMemo, useState } from 'react'
-import { useGetCurrentUserQuery } from '@common/api/userApi/user.api'
+import {
+  getNewEntityName,
+  isNewEntityValue,
+  makeNewEntityValue,
+} from '@utils/inlineCreate'
 
 export interface DomainsSelectProps {
   form: FormInstance
   edit?: boolean
   disabled?: boolean
   currentProfit?: any
+  // When true the user can create a brand-new provider inline: a persistent
+  // "Створити нового надавача" button in the dropdown switches the field into a
+  // name-input mode. The value becomes a `new::` sentinel that the owning form
+  // materializes into a real Domain on submit (see AddPaymentModal).
+  allowCreate?: boolean
 }
+
+const DOMAIN_TOOLTIP = 'Хто виставляє рахунок — ваша організація/ОСББ.'
 
 const DomainsSelect: React.FC<DomainsSelectProps> = ({
   form,
   edit,
   disabled,
   currentProfit,
+  allowCreate,
 }) => {
   const [domains, setDomains] = useState([])
+  const [search, setSearch] = useState('')
   const {
     data: fetchedDomains = [],
     isLoading: isDomainsLoading,
@@ -30,23 +44,64 @@ const DomainsSelect: React.FC<DomainsSelectProps> = ({
     }
   }, [fetchedDomains])
 
+  const domainValue = Form.useWatch('domain', form)
+  const isNew = isNewEntityValue(domainValue)
+
   const options = useMemo(() => {
-    return domains.map((i) => ({
-      value: i._id,
-      label: i.name,
-    }))
+    return domains.map((i) => ({ value: i._id, label: i.name }))
   }, [domains])
 
   useEffect(() => {
-    if (!edit && options.length === 1) {
+    // Auto-pick the only existing provider, but never while quick-creating.
+    if (!edit && !allowCreate && options.length === 1) {
       form.setFieldsValue({ domain: options[0].value })
     }
-  }, [form, options, edit])
+  }, [form, options, edit, allowCreate])
+
+  const enterCreateMode = () => {
+    form.setFieldValue('domain', makeNewEntityValue(search.trim()))
+    setSearch('')
+  }
+
+  if (isNew) {
+    return (
+      <Form.Item
+        name="domain"
+        label="Надавач послуг"
+        tooltip={DOMAIN_TOOLTIP}
+        getValueProps={(v) => ({
+          value: isNewEntityValue(v) ? getNewEntityName(v) : '',
+        })}
+        normalize={(input) => makeNewEntityValue(input ?? '')}
+        rules={[
+          {
+            validator: (_, v) =>
+              getNewEntityName(v ?? '').trim()
+                ? Promise.resolve()
+                : Promise.reject(new Error('Вкажіть назву надавача послуг')),
+          },
+        ]}
+        extra={
+          <Button
+            type="link"
+            size="small"
+            style={{ padding: 0 }}
+            onClick={() => form.setFieldValue('domain', undefined)}
+          >
+            ← обрати наявного
+          </Button>
+        }
+      >
+        <Input placeholder="Назва нового надавача послуг" />
+      </Form.Item>
+    )
+  }
 
   return (
     <Form.Item
       name="domain"
       label="Надавач послуг"
+      tooltip={DOMAIN_TOOLTIP}
       rules={!disabled && !currentProfit ? validateField('required') : []}
     >
       <Select
@@ -56,10 +111,36 @@ const DomainsSelect: React.FC<DomainsSelectProps> = ({
         status={isDomainsError && 'error'}
         loading={isDomainsLoading}
         disabled={
-          disabled ?? (isDomainsLoading || (domains.length <= 1 && !edit))
+          disabled ??
+          (isDomainsLoading || (!allowCreate && domains.length <= 1 && !edit))
         }
         allowClear
         showSearch
+        searchValue={search}
+        onSearch={setSearch}
+        onChange={() => setSearch('')}
+        popupRender={
+          allowCreate
+            ? (menu) => (
+                <>
+                  {menu}
+                  <Divider style={{ margin: '8px 0' }} />
+                  <Button
+                    type="text"
+                    block
+                    icon={<PlusOutlined />}
+                    style={{ textAlign: 'left' }}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={enterCreateMode}
+                  >
+                    {search.trim()
+                      ? `Створити «${search.trim()}»`
+                      : 'Створити нового надавача'}
+                  </Button>
+                </>
+              )
+            : undefined
+        }
       />
     </Form.Item>
   )

--- a/common/components/UI/Reusable/DomainsSelect.tsx
+++ b/common/components/UI/Reusable/DomainsSelect.tsx
@@ -1,4 +1,7 @@
-import { useGetDomainsQuery } from '@common/api/domainApi/domain.api'
+import {
+  useGetDomainsQuery,
+  useGetDomainTypeTemplatesQuery,
+} from '@common/api/domainApi/domain.api'
 import { validateField } from '@assets/features/validators'
 import { PlusOutlined } from '@ant-design/icons'
 import { Button, Divider, Form, FormInstance, Input, Select } from 'antd'
@@ -8,6 +11,7 @@ import {
   isNewEntityValue,
   makeNewEntityValue,
 } from '@utils/inlineCreate'
+import s from './DomainsSelect.module.scss'
 
 export interface DomainsSelectProps {
   form: FormInstance
@@ -16,12 +20,15 @@ export interface DomainsSelectProps {
   currentProfit?: any
   // When true the user can create a brand-new provider inline: a persistent
   // "Створити нового надавача" button in the dropdown switches the field into a
-  // name-input mode. The value becomes a `new::` sentinel that the owning form
-  // materializes into a real Domain on submit (see AddPaymentModal).
+  // name-input mode (+ a service-type picker). The value becomes a `new::`
+  // sentinel that the owning form materializes into a real Domain on submit
+  // (see AddPaymentModal).
   allowCreate?: boolean
 }
 
 const DOMAIN_TOOLTIP = 'Хто виставляє рахунок — ваша організація/ОСББ.'
+const TEMPLATE_TOOLTIP =
+  'Набір послуг для надавача. «Без послуг» — почати з чистого аркуша.'
 
 const DomainsSelect: React.FC<DomainsSelectProps> = ({
   form,
@@ -38,6 +45,9 @@ const DomainsSelect: React.FC<DomainsSelectProps> = ({
     isError: isDomainsError,
   } = useGetDomainsQuery({ archived: false })
 
+  const { data: typeTemplates = [], isLoading: isTemplatesLoading } =
+    useGetDomainTypeTemplatesQuery(undefined, { skip: !allowCreate })
+
   useEffect(() => {
     if (fetchedDomains.length) {
       setDomains(fetchedDomains)
@@ -51,6 +61,17 @@ const DomainsSelect: React.FC<DomainsSelectProps> = ({
     return domains.map((i) => ({ value: i._id, label: i.name }))
   }, [domains])
 
+  const templateOptions = useMemo(
+    () => [
+      { value: '', label: 'Без послуг' },
+      ...typeTemplates.map((t) => ({
+        value: t._id,
+        label: t.isBuiltIn ? t.name : `${t.name} (адмін)`,
+      })),
+    ],
+    [typeTemplates]
+  )
+
   useEffect(() => {
     // Auto-pick the only existing provider, but never while quick-creating.
     if (!edit && !allowCreate && options.length === 1) {
@@ -59,41 +80,67 @@ const DomainsSelect: React.FC<DomainsSelectProps> = ({
   }, [form, options, edit, allowCreate])
 
   const enterCreateMode = () => {
-    form.setFieldValue('domain', makeNewEntityValue(search.trim()))
+    form.setFieldsValue({
+      domain: makeNewEntityValue(search.trim()),
+      newDomainTemplateId: '',
+    })
     setSearch('')
+  }
+
+  const exitCreateMode = () => {
+    form.setFieldsValue({ domain: undefined, newDomainTemplateId: undefined })
   }
 
   if (isNew) {
     return (
-      <Form.Item
-        name="domain"
-        label="Надавач послуг"
-        tooltip={DOMAIN_TOOLTIP}
-        getValueProps={(v) => ({
-          value: isNewEntityValue(v) ? getNewEntityName(v) : '',
-        })}
-        normalize={(input) => makeNewEntityValue(input ?? '')}
-        rules={[
-          {
-            validator: (_, v) =>
-              getNewEntityName(v ?? '').trim()
-                ? Promise.resolve()
-                : Promise.reject(new Error('Вкажіть назву надавача послуг')),
-          },
-        ]}
-        extra={
-          <Button
-            type="link"
-            size="small"
-            style={{ padding: 0 }}
-            onClick={() => form.setFieldValue('domain', undefined)}
+      <>
+        <div className={s.createRow}>
+          <Form.Item
+            name="domain"
+            label="Надавач послуг"
+            tooltip={DOMAIN_TOOLTIP}
+            className={s.nameField}
+            getValueProps={(v) => ({
+              value: isNewEntityValue(v) ? getNewEntityName(v) : '',
+            })}
+            normalize={(input) => makeNewEntityValue(input ?? '')}
+            rules={[
+              {
+                validator: (_, v) =>
+                  getNewEntityName(v ?? '').trim()
+                    ? Promise.resolve()
+                    : Promise.reject(
+                        new Error('Вкажіть назву надавача послуг')
+                      ),
+              },
+            ]}
           >
-            ← обрати наявного
-          </Button>
-        }
-      >
-        <Input placeholder="Назва нового надавача послуг" />
-      </Form.Item>
+            <Input placeholder="Назва надавача" />
+          </Form.Item>
+          <Form.Item
+            name="newDomainTemplateId"
+            label="Напрямок послуг"
+            tooltip={TEMPLATE_TOOLTIP}
+            className={s.templateField}
+          >
+            <Select
+              options={templateOptions}
+              optionFilterProp="label"
+              placeholder="Без послуг"
+              loading={isTemplatesLoading}
+              showSearch
+            />
+          </Form.Item>
+        </div>
+        <Button
+          type="link"
+          size="small"
+          style={{ padding: 0, marginBottom: 8 }}
+          onClick={exitCreateMode}
+        >
+          ← обрати наявного
+        </Button>
+      </>
     )
   }
 

--- a/common/components/UI/Reusable/PaymentTypeSelect.tsx
+++ b/common/components/UI/Reusable/PaymentTypeSelect.tsx
@@ -9,6 +9,7 @@ const PaymentTypeSelect = () => {
     <Form.Item
       name="operation"
       label="Тип оплати"
+      tooltip="Дебет (Реалізація) — нарахування за послуги переліком; Кредит (Оплата) — разова сума одним рядком."
       rules={validateField('required')}
     >
       <Segmented

--- a/common/modules/hooks/usePaymentData.ts
+++ b/common/modules/hooks/usePaymentData.ts
@@ -9,6 +9,7 @@ import {
   parseMonthServicePlaceholder,
 } from '@common/components/Forms/AddPaymentForm/month-service-placeholder'
 import { Operations } from '@utils/constants'
+import { isNewEntityValue } from '@utils/inlineCreate'
 import { Form, FormInstance } from 'antd'
 import dayjs from 'dayjs'
 
@@ -156,7 +157,10 @@ export function usePaymentFormData(
     : undefined
 
   const { data: { data: { 0: company } } = { data: [null] } } =
-    useGetAllRealEstateQuery({ companyId, limit: 1 }, { skip: !companyId })
+    useGetAllRealEstateQuery(
+      { companyId, limit: 1 },
+      { skip: !companyId || isNewEntityValue(companyId) }
+    )
 
   const { data: { data: { 0: serviceById } } = { data: [null] } } =
     useGetAllServicesQuery(

--- a/pages/api/domain-type-templates/index.ts
+++ b/pages/api/domain-type-templates/index.ts
@@ -58,11 +58,10 @@ async function domainTypeTemplatesHandler(
 
   switch (req.method) {
     case 'GET': {
-      if (!isAdmin) {
-        return res
-          .status(403)
-          .json({ success: false, message: 'Немає доступу' })
-      }
+      // Read-only catalog of service-type templates. Any authenticated user may
+      // read it (e.g. a brand-new user picking a provider type in the invoice
+      // quick-create, before they become a DomainAdmin). Mutations stay
+      // admin-only below.
       const includeArchived = req.query.includeArchived === 'true'
       const filter = includeArchived ? {} : { archivedAt: null }
       const list = await DomainTypeTemplate.find(filter)

--- a/utils/domain/domain-type-template-services.test.ts
+++ b/utils/domain/domain-type-template-services.test.ts
@@ -1,0 +1,32 @@
+import { domainTypeTemplateToCustomServices } from './domain-type-template-services'
+
+describe('domainTypeTemplateToCustomServices', () => {
+  it('maps template groups to domain customServices', () => {
+    const tpl = {
+      groups: [
+        { groupName: 'Стандартні', serviceIds: ['1', '2'] },
+        { groupName: 'Додаткові', serviceIds: ['3'] },
+      ],
+    } as any
+
+    expect(domainTypeTemplateToCustomServices(tpl)).toEqual([
+      { groupName: 'Стандартні', services: ['1', '2'] },
+      { groupName: 'Додаткові', services: ['3'] },
+    ])
+  })
+
+  it('returns [] for null/undefined or no groups', () => {
+    expect(domainTypeTemplateToCustomServices(null)).toEqual([])
+    expect(domainTypeTemplateToCustomServices(undefined)).toEqual([])
+    expect(domainTypeTemplateToCustomServices({ groups: [] } as any)).toEqual(
+      []
+    )
+  })
+
+  it('stringifies serviceIds', () => {
+    const tpl = { groups: [{ groupName: 'A', serviceIds: [1, 2] }] } as any
+    expect(domainTypeTemplateToCustomServices(tpl)).toEqual([
+      { groupName: 'A', services: ['1', '2'] },
+    ])
+  })
+})

--- a/utils/domain/domain-type-template-services.ts
+++ b/utils/domain/domain-type-template-services.ts
@@ -1,0 +1,19 @@
+import { IDomainTypeTemplate } from '@common/api/domainApi/domain.api.types'
+
+export interface DomainCustomServiceGroup {
+  groupName: string
+  services: string[]
+}
+
+/**
+ * Map a DomainTypeTemplate into the `customServices` shape stored on a Domain.
+ * Mirrors the inline mapping the full DomainModal uses when seeding a new domain
+ * from its selected template (see DomainModal/index.tsx).
+ */
+export const domainTypeTemplateToCustomServices = (
+  template?: Pick<IDomainTypeTemplate, 'groups'> | null
+): DomainCustomServiceGroup[] =>
+  (template?.groups ?? []).map((g) => ({
+    groupName: g.groupName,
+    services: (g.serviceIds ?? []).map(String),
+  }))

--- a/utils/inlineCreate.test.ts
+++ b/utils/inlineCreate.test.ts
@@ -1,0 +1,35 @@
+import {
+  getNewEntityName,
+  isNewEntityValue,
+  makeNewEntityValue,
+} from './inlineCreate'
+
+describe('inlineCreate sentinel', () => {
+  it('wraps a name into a new-entity value verbatim (no trim)', () => {
+    expect(makeNewEntityValue('Моя ОСББ')).toBe('new::Моя ОСББ')
+    // whitespace is preserved so a controlled inline input can keep spaces
+    expect(makeNewEntityValue('Моя ')).toBe('new::Моя ')
+  })
+
+  it('detects new-entity values', () => {
+    expect(isNewEntityValue('new::Моя ОСББ')).toBe(true)
+    expect(isNewEntityValue('64f0c0c0c0c0c0c0c0c0c0c0')).toBe(false)
+    expect(isNewEntityValue(undefined)).toBe(false)
+    expect(isNewEntityValue(123)).toBe(false)
+  })
+
+  it('extracts the typed name back', () => {
+    expect(getNewEntityName('new::Моя ОСББ')).toBe('Моя ОСББ')
+  })
+
+  it('returns a plain id unchanged', () => {
+    expect(getNewEntityName('64f0c0c0c0c0c0c0c0c0c0c0')).toBe(
+      '64f0c0c0c0c0c0c0c0c0c0c0'
+    )
+  })
+
+  it('round-trips name -> value -> name', () => {
+    const name = 'ТОВ Ромашка'
+    expect(getNewEntityName(makeNewEntityValue(name))).toBe(name)
+  })
+})

--- a/utils/inlineCreate.ts
+++ b/utils/inlineCreate.ts
@@ -1,0 +1,18 @@
+// Sentinel for "create a new entity from a typed name on submit" (lazy create).
+// A Select field holding `new::<name>` means the user typed a brand-new name
+// that has no id yet; the owning form materializes the real entity on submit
+// (see AddPaymentModal). Kept as a string sentinel so the Select can render the
+// chosen new value like any other option without extra state.
+const NEW_PREFIX = 'new::'
+
+// Note: the name is stored verbatim (no trim) so a controlled inline name input
+// can keep whitespace while the user types a multi-word name. Trim where the
+// value is consumed (see materializeQuickEntities in AddPaymentModal).
+export const makeNewEntityValue = (name: string): string =>
+  `${NEW_PREFIX}${name}`
+
+export const isNewEntityValue = (value?: unknown): value is string =>
+  typeof value === 'string' && value.startsWith(NEW_PREFIX)
+
+export const getNewEntityName = (value: string): string =>
+  isNewEntityValue(value) ? value.slice(NEW_PREFIX.length) : value


### PR DESCRIPTION
Enable users to create providers (domains) and companies directly within the payment form using a `new::` sentinel pattern for lazy creation. Entities are materialized on final submit, allowing live preview of the invoice before completion.

Add an onboarding tour (InvoiceTour) that highlights each form field for new users, triggered automatically on first visit or via a help button.

Simplify the first-user flow to go directly to invoice creation rather than requiring separate provider/company setup steps.

Add tooltips to form fields and enhance selects (DomainsSelect, CompanySelect) with inline creation UI. Skip API calls for not-yet-created entities to prevent errors during preview.