### PR TITLE
Add Services for DomainAdmin

### DIFF
--- a/common/components/Pages/SettingsPage/index.tsx
+++ b/common/components/Pages/SettingsPage/index.tsx
@@ -60,6 +60,20 @@ export const AdminPanelPage: React.FC = () => {
                 </>
               ),
             },
+            ...(isGlobalAdmin || isDomainAdmin
+              ? [
+                  {
+                    key: 'customservices',
+                    label: 'Послуги',
+                    children: (
+                      <CustomServicesTable
+                        domains={domains}
+                        isDomainAdmin={isDomainAdmin}
+                      />
+                    ),
+                  },
+                ]
+              : []),
             ...(isGlobalAdmin
               ? [
                   {
@@ -88,15 +102,9 @@ export const AdminPanelPage: React.FC = () => {
                             onClick={() => setModalOpen(true)}
                           ></Button>
                         </Flex>
-
                         <FeatureFlagsTable />
                       </>
                     ),
-                  },
-                  {
-                    key: 'customservices',
-                    label: 'Послуги',
-                    children: <CustomServicesTable />,
                   },
                   {
                     key: 'templates',

--- a/common/components/Tables/CustomService/Table.test.tsx
+++ b/common/components/Tables/CustomService/Table.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { CustomServicesTable } from './Table'
+import { Roles } from '@utils/constants'
+
+jest.mock('@utils/servicesVisibility', () => ({
+  getVisibleServices: jest.fn((roles, adminDomains, allServices) => {
+    if (roles?.includes(Roles.DOMAIN_ADMIN)) {
+      const validDomainIds = adminDomains.map((d: any) => d._id)
+      return allServices.filter((s: any) => validDomainIds.includes(s.domain))
+    }
+    return allServices
+  }),
+  getDomainTypeTemplateCategoryLabel: jest.fn((cat) => cat),
+}))
+
+jest.mock('@common/api/userApi/user.api', () => ({
+  useGetCurrentUserQuery: jest.fn(),
+}))
+
+jest.mock('@common/api/customServicesApi/customServices.api', () => ({
+  useGetCustomServicesQuery: jest.fn(),
+  useDeleteCustomServiceMutation: jest.fn(() => [jest.fn()]),
+  useEditCustomServiceMutation: jest.fn(() => [
+    jest.fn(),
+    { isLoading: false },
+  ]),
+}))
+
+jest.mock('@common/api/domainApi/domain.api', () => ({
+  useGetDomainsByAdminQuery: jest.fn(),
+  useGetDomainsQuery: jest.fn(),
+  useGetDomainTypeTemplatesQuery: jest.fn(() => ({ data: [] })),
+}))
+
+const mockServices = [
+  {
+    _id: 's1',
+    name: 'Service Own 1',
+    domain: 'domain-own',
+    category: 'utility',
+  },
+  {
+    _id: 's2',
+    name: 'Service Own 2',
+    domain: 'domain-own',
+    category: 'utility',
+  },
+  {
+    _id: 's3',
+    name: 'Service Foreign',
+    domain: 'domain-foreign',
+    category: 'utility',
+  },
+]
+
+const mockAdminDomains = [{ _id: 'domain-own', name: 'My Domain' }]
+
+describe('CustomServicesTable - Права доступу Domain Admin', () => {
+  const mockUseGetCurrentUserQuery =
+    require('@common/api/userApi/user.api').useGetCurrentUserQuery
+  const mockUseGetCustomServicesQuery =
+    require('@common/api/customServicesApi/customServices.api').useGetCustomServicesQuery
+  const mockUseGetDomainsByAdminQuery =
+    require('@common/api/domainApi/domain.api').useGetDomainsByAdminQuery
+  const mockUseGetDomainsQuery =
+    require('@common/api/domainApi/domain.api').useGetDomainsQuery
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockUseGetCustomServicesQuery.mockReturnValue({
+      data: { data: mockServices },
+      isLoading: false,
+    })
+
+    mockUseGetDomainsByAdminQuery.mockReturnValue({ data: mockAdminDomains })
+    mockUseGetDomainsQuery.mockReturnValue({ data: [] })
+  })
+
+  it('Тест-кейс 1: Domain Admin бачить послуги своїх доменів', () => {
+    mockUseGetCurrentUserQuery.mockReturnValue({
+      data: { roles: [Roles.DOMAIN_ADMIN] },
+    })
+
+    render(<CustomServicesTable />)
+
+    expect(screen.getByText('Service Own 1')).toBeInTheDocument()
+    expect(screen.getByText('Service Own 2')).toBeInTheDocument()
+  })
+
+  it('Тест-кейс 2: Domain Admin не бачить послуги чужих доменів', () => {
+    mockUseGetCurrentUserQuery.mockReturnValue({
+      data: { roles: [Roles.DOMAIN_ADMIN] },
+    })
+
+    render(<CustomServicesTable />)
+
+    expect(screen.queryByText('Service Foreign')).not.toBeInTheDocument()
+  })
+})

--- a/common/components/Tables/CustomService/Table.tsx
+++ b/common/components/Tables/CustomService/Table.tsx
@@ -38,7 +38,15 @@ import {
   DOMAIN_TYPE_TEMPLATE_CATEGORY_OPTIONS,
 } from '@utils/domain/domain-type-template-categories'
 
-export const CustomServicesTable: React.FC = () => {
+export interface CustomServicesTableProps {
+  domains?: any[]
+  isDomainAdmin?: boolean
+}
+
+export const CustomServicesTable: React.FC<CustomServicesTableProps> = ({
+  domains: passedDomains,
+  isDomainAdmin: passedIsDomainAdmin,
+}) => {
   const { data: user } = useGetCurrentUserQuery()
   const isGlobalAdmin = user?.roles?.includes(Roles.GLOBAL_ADMIN)
   const isDomainAdmin = user?.roles?.includes(Roles.DOMAIN_ADMIN)


### PR DESCRIPTION
https://app.asana.com/1/1202389091502512/project/1214169728867936/task/1215771138817105?focus=true

До
<img width="1588" height="738" alt="{AE7BD73C-8E81-4CAC-889E-F4892C7710DB}" src="https://github.com/user-attachments/assets/09d1d16b-1483-483b-8176-4429a6b3d397" />

Після
<img width="1578" height="617" alt="image" src="https://github.com/user-attachments/assets/50132231-9cf2-4a72-9b02-21893e649a89" />


Покриття тестами

Написано юніт-тести для компонента таблиці послуг (Table.test.tsx), які перевіряють два цільові сценарії:
- Domain Admin успішно бачить послуги, прив'язані до його доменів.
- Domain Admin не бачить послуги з доменів, до яких у нього немає доступу.