### PR TITLE
Використовувати category замість name у модалці створення інвойсу

### DIFF
--- a/common/components/UI/Reusable/DomainsSelect.test.tsx
+++ b/common/components/UI/Reusable/DomainsSelect.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { Form } from 'antd'
 import DomainsSelect from './DomainsSelect'
 import {
@@ -30,7 +30,7 @@ const Wrapper = ({ allowCreate = false }: { allowCreate?: boolean }) => {
   )
 }
 
-const getDomainInput = () => screen.getByRole('combobox')
+const getDomainInput = () => screen.getAllByRole('combobox')[0]
 const domainValue = () => screen.getByTestId('domain-value').textContent
 
 // Simulate typing a name into the search box and leaving the field.
@@ -81,7 +81,6 @@ describe('DomainsSelect — поле надавача послуг', () => {
     typeAndBlur('Alpha')
 
     expect(domainValue()).toBe('d1')
-    // не перейшли в режим створення
     expect(screen.queryByPlaceholderText('Назва надавача')).toBeNull()
   })
 
@@ -109,7 +108,6 @@ describe('DomainsSelect — поле надавача послуг', () => {
     typeAndBlur('Gamma')
 
     expect(domainValue()).toBe('new::Gamma')
-    // автоматично показались додаткові поля
     expect(
       await screen.findByPlaceholderText('Назва надавача')
     ).toBeInTheDocument()
@@ -171,7 +169,6 @@ describe('DomainsSelect — поле надавача послуг', () => {
   })
 
   it('пошук лише серед доступних користувачу: чужа назва вважається новою', () => {
-    // Beta існує в іншого користувача, тож його немає у відповіді запиту.
     mockDomains.mockReturnValue({
       data: [{ _id: 'd1', name: 'Alpha' }],
       isLoading: false,
@@ -199,5 +196,40 @@ describe('DomainsSelect — поле надавача послуг', () => {
 
     expect(domainValue()).not.toContain('new::')
     expect(screen.queryByPlaceholderText('Назва надавача')).toBeNull()
+  })
+
+  it('формує список напрямків послуг за категорією, уникаючи дублікатів (замість name)', async () => {
+    mockTemplates.mockReturnValue({
+      data: [
+        { _id: 't1', name: 'IT template 1', category: 'IT' },
+        { _id: 't2', name: 'IT template 2', category: 'IT' },
+        { _id: 't3', name: 'Real Estate admin', category: 'real-estate' },
+        { _id: 't4', name: 'NoCategory' },
+      ],
+      isLoading: false,
+    })
+
+    mockDomains.mockReturnValue({ data: [], isLoading: false, isError: false })
+
+    render(<Wrapper allowCreate />)
+
+    expect(
+      await screen.findByPlaceholderText('Назва надавача')
+    ).toBeInTheDocument()
+
+    const templateInput = screen.getByRole('combobox')
+
+    fireEvent.mouseDown(templateInput)
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Без послуг').length).toBeGreaterThan(0)
+      expect(screen.getByText('IT')).toBeInTheDocument()
+      expect(screen.getByText('real-estate')).toBeInTheDocument()
+      expect(screen.getByText('NoCategory')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('IT template 1')).toBeNull()
+    expect(screen.queryByText('IT template 2')).toBeNull()
+    expect(screen.queryByText('Real Estate admin')).toBeNull()
   })
 })

--- a/common/components/UI/Reusable/DomainsSelect.tsx
+++ b/common/components/UI/Reusable/DomainsSelect.tsx
@@ -18,7 +18,6 @@ export interface DomainsSelectProps {
   disabled?: boolean
   currentProfit?: any
   // When true the user can create a brand-new provider inline: a persistent
-  // "Створити нового надавача" button in the dropdown switches the field into a
   // name-input mode (+ a service-type picker). The value becomes a `new::`
   // sentinel that the owning form materializes into a real Domain on submit
   // (see AddPaymentModal).
@@ -53,16 +52,25 @@ const DomainsSelect: React.FC<DomainsSelectProps> = ({
     return domains.map((i) => ({ value: i._id, label: i.name }))
   }, [domains])
 
-  const templateOptions = useMemo(
-    () => [
-      { value: '', label: 'Без послуг' },
-      ...typeTemplates.map((t) => ({
-        value: t._id,
-        label: t.isBuiltIn ? t.name : `${t.name} (адмін)`,
-      })),
-    ],
-    [typeTemplates]
-  )
+  const templateOptions = useMemo(() => {
+    const uniqueCategories = new Map()
+
+    typeTemplates.forEach((t) => {
+      const categoryLabel = t.category || t.name
+      if (!uniqueCategories.has(categoryLabel)) {
+        uniqueCategories.set(categoryLabel, t._id)
+      }
+    })
+
+    const mappedOptions = Array.from(uniqueCategories.entries()).map(
+      ([label, id]) => ({
+        value: id,
+        label: label,
+      })
+    )
+
+    return [{ value: '', label: 'Без послуг' }, ...mappedOptions]
+  }, [typeTemplates])
 
   useEffect(() => {
     // Auto-pick the only existing provider, but never while quick-creating.


### PR DESCRIPTION
https://app.asana.com/1/1202389091502512/project/1214169728867936/task/1216520537791404?focus=true

До
<img width="1241" height="579" alt="image" src="https://github.com/user-attachments/assets/74cfdc69-5fe8-43ba-b8d1-4a5ff57424c7" />


Після
<img width="1260" height="583" alt="image" src="https://github.com/user-attachments/assets/99160abb-9f23-4f94-acab-7e024e65dab8" />


Також додано новий тест для перевірки логіки групування та унікальності категорій у випадаючому списку