### PR TITLE
feat: add deletion of realestate for domain admin

### DIFF
--- a/common/components/Tables/Companies/Table.tsx
+++ b/common/components/Tables/Companies/Table.tsx
@@ -602,7 +602,7 @@ const getDefaultColumns = ({
                   </Popconfirm>
                 ),
               },
-              isGlobalAdmin && {
+              (isGlobalAdmin || isAdmin) && {
                 key: 'delete',
                 label: (
                   <Popconfirm

--- a/pages/api/real-estate/[id]/index.ts
+++ b/pages/api/real-estate/[id]/index.ts
@@ -17,25 +17,54 @@ export default async function handler(
     case 'DELETE':
       try {
         if (isGlobalAdmin) {
-          await RealEstate.findByIdAndRemove(req.query.id).then(
-            (realEstate) => {
-              if (realEstate) {
-                return res.status(200).json({
-                  success: true,
-                  data: 'RealEstate ' + req.query.id + ' was deleted',
-                })
-              } else {
-                return res.status(400).json({
-                  success: false,
-                  data: 'RealEstate ' + req.query.id + ' was not found',
-                })
-              }
-            }
-          )
+          const realEstate = await RealEstate.findByIdAndRemove(req.query.id)
+          if (realEstate) {
+            return res.status(200).json({
+              success: true,
+              data: 'realestate ' + req.query.id + ' was deleted',
+            })
+          } else {
+            return res.status(404).json({
+              success: false,
+              message: 'realestate not found',
+            })
+          }
         }
-        return res.status(400).json({ success: false, message: 'not allowed' })
+
+        if (isAdmin) {
+          const adminDomains = await Domain.find({
+            adminEmails: { $in: [user.email] },
+          })
+          const adminDomainIds = adminDomains?.map((d) => d._id.toString())
+
+          const currentRealEstate = await RealEstate.findById(req.query.id)
+
+          if (!currentRealEstate) {
+            return res.status(404).json({
+              success: false,
+              message: 'realestate not found',
+            })
+          }
+
+          const currentDomainId = currentRealEstate.domain?.toString()
+
+          if (!currentDomainId || !adminDomainIds?.includes(currentDomainId)) {
+            return res.status(403).json({
+              success: false,
+              message: 'not allowed',
+            })
+          }
+
+          await RealEstate.findByIdAndRemove(req.query.id)
+          return res.status(200).json({
+            success: true,
+            data: 'realestate ' + req.query.id + ' was deleted',
+          })
+        }
+
+        return res.status(403).json({ success: false, message: 'not allowed' })
       } catch (error) {
-        return res.status(400).json({ success: false, error })
+        return res.status(400).json({ success: false, error: error.message })
       }
 
     case 'PATCH':

--- a/pages/api/real-estate/[id]/realestates.test.ts
+++ b/pages/api/real-estate/[id]/realestates.test.ts
@@ -323,3 +323,119 @@ describe('RealEstate API - PATCH', () => {
     expect(response.data.notValidField).toBe(undefined)
   })
 })
+
+describe('RealEstate API - DELETE', () => {
+  it('should be able to successfully remove the company as GlobalAdmin', async () => {
+    await mockLoginAs(users.globalAdmin)
+
+    const mockReq = {
+      method: 'DELETE',
+      query: { id: realEstates[0]._id },
+    } as any
+    const mockRes = {
+      status: jest.fn(() => mockRes),
+      json: jest.fn(),
+    } as any
+
+    await handler(mockReq, mockRes)
+
+    expect(mockRes.status).toHaveBeenCalledWith(200)
+    expect(mockRes.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+      })
+    )
+  })
+
+  it('should be able to successfully remove his company from his domain as DomainAdmin', async () => {
+    await mockLoginAs(users.domainAdmin)
+
+    const mockReq = {
+      method: 'DELETE',
+      query: { id: realEstates[0]._id },
+    } as any
+    const mockRes = {
+      status: jest.fn(() => mockRes),
+      json: jest.fn(),
+    } as any
+
+    await handler(mockReq, mockRes)
+
+    expect(mockRes.status).toHaveBeenCalledWith(200)
+    expect(mockRes.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+      })
+    )
+  })
+
+  it('should prevent a company from deleting another domain as DomainAdmin', async () => {
+    await mockLoginAs(users.domainAdmin)
+
+    const mockReq = {
+      method: 'DELETE',
+      query: { id: realEstates[1]._id },
+    } as any
+    const mockRes = {
+      status: jest.fn(() => mockRes),
+      json: jest.fn(),
+    } as any
+
+    await handler(mockReq, mockRes)
+
+    expect(mockRes.status).toHaveBeenCalledWith(403)
+    expect(mockRes.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: expect.stringContaining('not allowed'),
+      })
+    )
+  })
+
+  it('should return a 404 error when attempting to delete a nonexistent company (DomainAdmin)', async () => {
+    await mockLoginAs(users.domainAdmin)
+
+    const fakeId = '64d68421d9ba2fc8fea79dff'
+    const mockReq = {
+      method: 'DELETE',
+      query: { id: fakeId },
+    } as any
+    const mockRes = {
+      status: jest.fn(() => mockRes),
+      json: jest.fn(),
+    } as any
+
+    await handler(mockReq, mockRes)
+
+    expect(mockRes.status).toHaveBeenCalledWith(404)
+    expect(mockRes.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: 'realestate not found',
+      })
+    )
+  })
+
+  it('should prevent ordinary users from deleting the company (User)', async () => {
+    await mockLoginAs(users.user)
+
+    const mockReq = {
+      method: 'DELETE',
+      query: { id: realEstates[0]._id },
+    } as any
+    const mockRes = {
+      status: jest.fn(() => mockRes),
+      json: jest.fn(),
+    } as any
+
+    await handler(mockReq, mockRes)
+
+    expect(mockRes.status).toHaveBeenCalledWith(403)
+    expect(mockRes.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: expect.stringContaining('not allowed'),
+      })
+    )
+  })
+})


### PR DESCRIPTION
https://app.asana.com/1/1202389091502512/project/1202389032764573/task/1216718988548001

Test deletion of "realestate" in Postman, where domain admin doesn't allowed.
<img width="1505" height="877" alt="image_2026-07-22_19-55-43" src="https://github.com/user-attachments/assets/343ea24c-9bd6-418e-82b8-469216a8ee55" />
