### PR TITLE
fix: commented dropdownStyle

### DIFF
--- a/common/components/StreetsSelector/index.tsx
+++ b/common/components/StreetsSelector/index.tsx
@@ -39,7 +39,7 @@ const StreetsSelector: React.FC<StreetsSelectorProps> = ({
       allowClear
       className={className}
       options={options}
-      dropdownStyle={{ width: 'max-content' }}
+      // dropdownStyle={{ width: 'max-content' }}
       {...props}
     />
   )

--- a/common/components/StreetsSelector/index.tsx
+++ b/common/components/StreetsSelector/index.tsx
@@ -1,5 +1,6 @@
 import { Select } from 'antd'
 import { IFilter } from '@common/api/paymentApi/payment.api.types'
+import styles from './style.module.scss'
 
 interface StreetsSelectorProps {
   streets: IFilter[]
@@ -38,8 +39,9 @@ const StreetsSelector: React.FC<StreetsSelectorProps> = ({
       }}
       allowClear
       className={className}
+      popupMatchSelectWidth={false}
+      dropdownClassName={styles.streetDropdown}
       options={options}
-      // dropdownStyle={{ width: 'max-content' }}
       {...props}
     />
   )

--- a/common/components/StreetsSelector/style.module.scss
+++ b/common/components/StreetsSelector/style.module.scss
@@ -6,3 +6,13 @@
 .streetSelector {
   min-width: 200px;
 }
+
+.streetDropdown {
+  min-width: 250px !important;
+  max-width: 300px !important;
+
+  :global(.ant-select-item-option-content) {
+    white-space: normal;
+    word-break: break-word;
+  }
+}


### PR DESCRIPTION
The “width: 'max-content'” value causes the “street” filter to display incorrectly, so I commented it out