### PR TITLE
фікс "Позначити оплату"

### DIFF
--- a/pages/api/spacehub/payment/mark-paid/index.ts
+++ b/pages/api/spacehub/payment/mark-paid/index.ts
@@ -17,7 +17,6 @@ const COPYABLE_PAYMENT_FIELDS = [
   'company',
   'monthService',
   'description',
-  'invoice',
   'provider',
   'reciever',
   'generalSum',
@@ -87,6 +86,7 @@ export default async function handler(
         type: Operations.Credit,
         invoiceCreationDate: dateShiftMs(source.invoiceCreationDate, 1),
         invoiceNumber: await getNextInvoiceNumber(),
+        invoice: [],
       }
       for (const field of COPYABLE_PAYMENT_FIELDS) {
         if (source[field] !== undefined) {

--- a/pages/api/spacehub/payment/mark-paid/mark-paid.test.ts
+++ b/pages/api/spacehub/payment/mark-paid/mark-paid.test.ts
@@ -124,6 +124,25 @@ describe('Payment API Endpoint - mark-paid', () => {
     expect(ProfitService.updatePayment).toHaveBeenCalledTimes(2)
   })
 
+  it('creates the credit payment with an empty invoice array, not the source services', async () => {
+    await mockLoginAs(users.globalAdmin)
+    const sourceWithServices = {
+      ...debitPayments[0],
+      invoice: [{ service: 'test-service', sum: 100 }],
+    }
+    ;(Payment.find as jest.Mock).mockResolvedValue([sourceWithServices])
+    ;(Payment.create as jest.Mock).mockImplementation((data: any) =>
+      Promise.resolve({ ...data, _id: 'credit-id' })
+    )
+    ;(PaymentChangeLog.create as jest.Mock).mockResolvedValue({})
+    ;(ProfitService.updatePayment as jest.Mock).mockResolvedValue({})
+
+    await performRequest('POST', { ids: [sourceWithServices._id] })
+
+    const createArg = (Payment.create as jest.Mock).mock.calls[0][0]
+    expect(createArg.invoice).toEqual([])
+  })
+
   it('skips already-paid (credit) payments — only debit can be marked', async () => {
     await mockLoginAs(users.globalAdmin)
     ;(Payment.find as jest.Mock).mockResolvedValue([creditPayment])


### PR DESCRIPTION
https://app.asana.com/1/1202389091502512/project/1202389032764573/task/1217044606868737?focus=true

До
<img width="1655" height="474" alt="image" src="https://github.com/user-attachments/assets/bdbd4f48-a6d0-4939-81a4-7a27bcc54b78" />


Після
<img width="1589" height="342" alt="{D2EF9979-3B5D-462A-8C3B-9F93BE8FD25D}" src="https://github.com/user-attachments/assets/529cf0a0-bd17-4a41-be0b-ca9cb026e960" />


Також додано новий unit-тест: якщо у вихідного Debit-платежу заповнений invoice з послугами, створений Credit-платіж отримує invoice: []. 