### PR TITLE
Дослідити та усунути deprecated налаштування в tsconfig.json

### DIFF
--- a/common/components/Pages/SignInPage/index.tsx
+++ b/common/components/Pages/SignInPage/index.tsx
@@ -1,5 +1,5 @@
 import { useFeatureFlag } from '@modules/hooks/useFeatureFlag'
-import { BuiltInProviderType } from 'next-auth/providers'
+import { BuiltInProviderType } from 'next-auth/providers/index'
 import { ClientSafeProvider, LiteralUnion } from 'next-auth/react'
 import { FC } from 'react'
 import SignInForm from '@components/Forms/AddSingInForm'

--- a/pages/auth/signin/index.tsx
+++ b/pages/auth/signin/index.tsx
@@ -1,5 +1,5 @@
 import { authOptions } from '../../api/auth/[...nextauth]'
-import { BuiltInProviderType } from 'next-auth/providers'
+import { BuiltInProviderType } from 'next-auth/providers/index'
 import SignInPage from '@components/Pages/SignInPage'
 import MainLayout from '@components/Layouts/Main'
 import { getServerSession } from 'next-auth'

--- a/pages/auth/signup/index.tsx
+++ b/pages/auth/signup/index.tsx
@@ -4,7 +4,7 @@ import { AppRoutes, errors } from '@utils/constants'
 import { Alert } from 'antd'
 import { GetServerSideProps } from 'next'
 import { getServerSession } from 'next-auth'
-import { BuiltInProviderType } from 'next-auth/providers'
+import { BuiltInProviderType } from 'next-auth/providers/index'
 import {
   ClientSafeProvider,
   getCsrfToken,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,23 +11,22 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
     "types": ["node", "jest"],
-    "baseUrl": ".",
     "paths": {
-      "@public/*": ["public/*"],
-      "@utils/*": ["utils/*"],
-      "@styles/*": ["styles/*"],
-      "@pages/*": ["pages/*"],
-      "@components/*": ["common/components/*"],
-      "@assets/*": ["common/assets/*"],
-      "@modules/*": ["common/modules/*"],
-      "@lib/*": ["common/lib/*"],
-      "@common/*": ["common/*"]
+      "@public/*": ["./public/*"],
+      "@utils/*": ["./utils/*"],
+      "@styles/*": ["./styles/*"],
+      "@pages/*": ["./pages/*"],
+      "@components/*": ["./common/components/*"],
+      "@assets/*": ["./common/assets/*"],
+      "@modules/*": ["./common/modules/*"],
+      "@lib/*": ["./common/lib/*"],
+      "@common/*": ["./common/*"]
     }
   },
   "include": [


### PR DESCRIPTION
https://app.asana.com/1/1202389091502512/project/1202389032764573/task/1217123945906146?focus=true

* Оновлено moduleResolution: Значення "node" змінено на "bundler". Старий алгоритм node10 визнано застарілим у TS 6.0, оскільки він ігнорує поле "exports" у package.json. Режим "bundler" ідеально підходить для Next.js/webpack та не вимагає розширень .js у TS-файлах

* Видалено baseUrl: Опцію прибрано відповідно до рекомендацій команди TypeScript. Її значення перенесено безпосередньо у кожен запис масиву paths (наприклад, "./public/*"). Це не ламає ts-jest, оскільки pathsToModuleNameMapper використовує явний префікс '<rootDir>/'

* Виправлено імпорти next-auth: Оскільки "bundler" суворо перевіряє "exports" пакетів, імпорт BuiltInProviderType з 'next-auth/providers' перестав компілюватись (пакет експортує лише "./providers/*"). Шляхи оновлено на 'next-auth/providers/index' у:
  - common/components/Pages/SignInPage/index.tsx
  - pages/auth/signin/index.tsx
  - pages/auth/signup/index.tsx

Перевірка проведена, все працює коректно